### PR TITLE
feat: add context bridge for cloud ui mode

### DIFF
--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -20,6 +20,9 @@ import { EditorContext, EditorUtils } from "../integrations/editor/EditorUtils"
 import * as path from "path"
 import { handleGenerateCommitMessage } from "../core/costrict/commit"
 import { getTerminalManager } from "../core/costrict/cli-wrap"
+import { getConfiguredUiMode, UiMode, UI_MODE_OPTIONS } from "../shared/uiMode"
+import type { AssistantUIContextMessage } from "../core/cs-cloud/extension/types"
+import { sendContextToCloudWithFocus } from "../core/cs-cloud/extension/contextBridge"
 
 interface UriSource {
 	path: string
@@ -30,42 +33,6 @@ interface UriSource {
 interface ProcessedResource {
 	type: "path" | "image"
 	content: string
-}
-
-type UiMode = "classic" | "cloud"
-
-const uiModeQuickPickItems: Array<{
-	label: string
-	description: string
-	value: UiMode
-}> = [
-	{
-		label: "Classic Mode",
-		description: "Use the current CoStrict UI and logic",
-		value: "classic",
-	},
-	{
-		label: "Cloud Mode",
-		description: "Use the Cloud UI on next launch",
-		value: "cloud",
-	},
-]
-
-export const getConfiguredUiMode = (): UiMode => {
-	const configured = vscode.workspace.getConfiguration(Package.commandIDPrefix).get<UiMode>("uiMode")
-	return configured === "cloud" ? "cloud" : "classic"
-}
-
-const promptToReloadForUiModeChange = async () => {
-	const reloadNow = await vscode.window.showInformationMessage(
-		"UI mode updated. Reload Window to apply.",
-		"Reload Now",
-		"Later",
-	)
-
-	if (reloadNow === "Reload Now") {
-		await vscode.commands.executeCommand("workbench.action.reloadWindow")
-	}
 }
 
 /**
@@ -188,7 +155,7 @@ export const getCommandsMap = ({
 	switchUiMode: async () => {
 		const currentMode = getConfiguredUiMode()
 		const selection = await vscode.window.showQuickPick(
-			uiModeQuickPickItems.map((item) => ({
+			UI_MODE_OPTIONS.map((item) => ({
 				...item,
 				detail: item.value === currentMode ? "Current mode" : undefined,
 			})),
@@ -339,6 +306,64 @@ export const getCommandsMap = ({
 		visibleProvider.postMessageToWebview({ type: "acceptInput" })
 	},
 	addFileToContext: async (...args: [UriSource] | [unknown, UriSource[]]) => {
+		// Cloud 模式：不依赖 ClineProvider，提前分流
+		if (getConfiguredUiMode() === "cloud") {
+			const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+			if (!cwd) return
+
+			let sources: (UriSource | EditorContext)[] = []
+			if (args.length > 1 && Array.isArray(args[1]) && args[1].length > 0) {
+				sources = args[1]
+			} else {
+				let singleSource: UriSource | EditorContext | undefined | null
+				if (args.length > 0) {
+					;[singleSource] = args as [UriSource]
+				} else {
+					singleSource = EditorUtils.getEditorContext()
+				}
+				if (singleSource) {
+					sources = [singleSource]
+				}
+			}
+
+			if (sources.length === 0) return
+
+			const processedResources = (
+				await Promise.all(
+					sources.map(async (source): Promise<ProcessedResource | null> => {
+						if (!(source as UriSource).path && !(source as EditorContext).filePath) {
+							return null
+						}
+						const resourceUri = vscode.Uri.parse(
+							(source as UriSource).path || path.join(cwd, (source as EditorContext).filePath),
+						)
+						return createAliasedPath(resourceUri)
+					}),
+				)
+			).filter((p): p is ProcessedResource => !!p)
+
+			if (processedResources.length === 0) return
+
+			const textPaths: string[] = []
+			const imageSources: string[] = []
+			for (const resource of processedResources) {
+				if (resource.type === "path") textPaths.push(resource.content)
+				else if (resource.type === "image") imageSources.push(resource.content)
+			}
+
+			const chatMessage = textPaths.length > 0 ? textPaths.join(" ") + " " : ""
+			const payload: AssistantUIContextMessage = {
+				type: "assistantUIContext",
+				text: chatMessage,
+				focus: true,
+			}
+			if (imageSources.length > 0) payload.images = imageSources
+
+			await sendContextToCloudWithFocus(payload)
+			return
+		}
+
+		// Classic 模式：现有逻辑不变
 		const visibleProvider = await ClineProvider.getInstance()
 		if (!visibleProvider) {
 			return

--- a/src/core/cs-cloud/extension/contextBridge.ts
+++ b/src/core/cs-cloud/extension/contextBridge.ts
@@ -1,0 +1,120 @@
+import * as vscode from "vscode"
+import type { AssistantUIContextMessage, SendContextResult } from "./types"
+
+interface CloudProvider {
+	postContextMessage(message: AssistantUIContextMessage): Thenable<boolean> | undefined
+}
+
+let activeProvider: CloudProvider | undefined
+let cloudUiGeneration = 0
+let cloudUiReady = false
+let isCloudUnavailable = false
+const pendingQueue: AssistantUIContextMessage[] = []
+
+/**
+ * 由 AssistantUISidebarProvider 在 resolveWebviewView() 中调用，
+ * 通知 bridge 当前活跃 provider。
+ * provider 变更时自动重置 ready 状态和递增 generation。
+ * 不清空 pendingQueue — 新消息可能已在 focus 等待期间入队；
+ * onCloudUiReady 的 generation 校验足以过滤旧 webview 的 late ready。
+ * @returns 当前 generation，调用方需传入 onCloudUiReady。
+ */
+export function setActiveCloudProvider(provider: CloudProvider | undefined): number {
+	if (activeProvider !== provider) {
+		cloudUiReady = false
+		isCloudUnavailable = false
+		cloudUiGeneration++
+	}
+	activeProvider = provider
+	if (!provider) {
+		cloudUiReady = false
+		isCloudUnavailable = true
+		pendingQueue.length = 0
+	}
+	return cloudUiGeneration
+}
+
+/**
+ * Cloud UI 加载完成后调用（iframe 模式由 wrapper 转发 ASSISTANT_UI_READY，
+ * static 模式由 Cloud UI hook 直接通知）。
+ * @param generation 必须传入 setActiveCloudProvider 返回的 generation，用于校验是否匹配。
+ */
+export function onCloudUiReady(generation: number) {
+	if (generation !== cloudUiGeneration) {
+		// 旧 webview 的 late ready，忽略
+		return
+	}
+	isCloudUnavailable = false
+	cloudUiReady = true
+	const toFlush = pendingQueue.splice(0)
+	for (const msg of toFlush) {
+		doSendContextMessage(msg)
+	}
+}
+
+/**
+ * Cloud UI 不可用时调用（disabled / error 状态），
+ * 设置 unavailable 标记让后续 sendContextToCloud 直接返回 "unavailable"，
+ * 避免消息永远堆积在 queue 中。
+ */
+export function setCloudUnavailable(reason: string) {
+	console.warn(`[contextBridge] Cloud UI unavailable: ${reason}. Dropping ${pendingQueue.length} queued messages.`)
+	isCloudUnavailable = true
+	cloudUiReady = false
+	pendingQueue.length = 0
+}
+
+/**
+ * 发送 context 到 Cloud UI。
+ * - "sent": 已立即发出
+ * - "queued": Cloud UI 未 ready，已入队等待（ready 后自动 flush）
+ * - "unavailable": 无活跃 provider 或 Cloud UI 已标记不可用，消息丢弃
+ */
+export function sendContextToCloud(message: AssistantUIContextMessage): SendContextResult {
+	if (isCloudUnavailable || !activeProvider) {
+		console.warn("[contextBridge] Cloud provider unavailable or not active, dropping context message")
+		return "unavailable"
+	}
+	if (!cloudUiReady) {
+		pendingQueue.push(message)
+		return "queued"
+	}
+	doSendContextMessage(message)
+	return "sent"
+}
+
+function doSendContextMessage(message: AssistantUIContextMessage) {
+	const result = activeProvider!.postContextMessage(message)
+	if (result) {
+		result.then(
+			(delivered) => {
+				if (!delivered) {
+					console.warn("[contextBridge] postMessage returned false, webview may not be ready")
+				}
+			},
+			(err) => {
+				console.error("[contextBridge] postMessage failed:", err)
+			},
+		)
+	}
+}
+
+/**
+ * 先聚焦 Cloud sidebar，再发送 context。
+ * 应作为 Cloud 模式下 add-to-context 命令的统一入口。
+ * 使用轮询等待 activeProvider 注册（首次聚焦 Cloud sidebar 时可能需要异步启动）。
+ * 超时后不 queue——返回 "unavailable" 由调用方决定是否重试。
+ */
+export async function sendContextToCloudWithFocus(message: AssistantUIContextMessage): Promise<SendContextResult> {
+	await vscode.commands.executeCommand("costrict.AssistantUISidebarProvider.focus")
+	// 轮询等待 activeProvider 注册，超时 2s
+	const deadline = Date.now() + 2000
+	while (!activeProvider && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 50))
+	}
+	if (isCloudUnavailable || !activeProvider) {
+		console.warn("[contextBridge] Cloud provider unavailable after focus, dropping message")
+		return "unavailable"
+	}
+	return sendContextToCloud(message)
+}

--- a/src/core/cs-cloud/extension/html.ts
+++ b/src/core/cs-cloud/extension/html.ts
@@ -324,6 +324,10 @@ export function getAssistantUIStaticHtml(
           const v=acquireVsCodeApi();
           window.__VSCODE_API__=v;
           window.addEventListener("message",function(e){
+            if (e.data?.type === "ASSISTANT_UI_READY") {
+              v.postMessage({ type: "ASSISTANT_UI_READY" });
+              return;
+            }
             if(e.data?.type==="FETCH_QUOTA"){
               v.postMessage({type:"fetchQuota",baseUrl:e.data.baseUrl,token:e.data.token});
             }
@@ -453,21 +457,40 @@ export function getAssistantUIIframeHtml(
         frame.addEventListener("load", function () {
           window.__ASSISTANT_UI_HIDE_LOADING__();
           if (frame.contentWindow && window.__CS_CLOUD_ACCESS_TOKEN__) {
-            frame.contentWindow.postMessage({ type: "ACCESS_TOKEN", token: window.__CS_CLOUD_ACCESS_TOKEN__ }, "*");
+            frame.contentWindow.postMessage({ type: "ACCESS_TOKEN", token: window.__CS_CLOUD_ACCESS_TOKEN__ }, frameOrigin);
           }
         });
       }
       setTimeout(window.__ASSISTANT_UI_HIDE_LOADING__, 8000);
     });
     const vscodeApi = acquireVsCodeApi();
+    const frameOrigin = new URL(window.__ASSISTANT_UI_FRAME_URL__).origin;
+    let cloudFrameReady = false;
+    const pendingFrameMessages = [];
+
+    function flushFrameMessages() {
+      const frame = document.getElementById("cloud-frame");
+      if (!frame?.contentWindow) return;
+      const msgs = pendingFrameMessages.splice(0);
+      for (const data of msgs) {
+        frame.contentWindow.postMessage(data, frameOrigin);
+      }
+    }
+
     window.addEventListener("message", function (event) {
       const frame = document.getElementById("cloud-frame");
 
       // 来自 iframe 的消息：转发给 VS Code
       if (event.source === frame?.contentWindow) {
+        if (event.data?.type === "ASSISTANT_UI_READY") {
+          cloudFrameReady = true;
+          flushFrameMessages();
+          vscodeApi.postMessage({ type: "ASSISTANT_UI_READY" });
+          return;
+        }
         if (event.data?.type === "REQUEST_ACCESS_TOKEN") {
           if (frame.contentWindow && window.__CS_CLOUD_ACCESS_TOKEN__) {
-            frame.contentWindow.postMessage({ type: "ACCESS_TOKEN", token: window.__CS_CLOUD_ACCESS_TOKEN__ }, "*");
+            frame.contentWindow.postMessage({ type: "ACCESS_TOKEN", token: window.__CS_CLOUD_ACCESS_TOKEN__ }, frameOrigin);
           }
           return;
         }
@@ -492,15 +515,23 @@ export function getAssistantUIIframeHtml(
       }
 
       // 来自 VS Code 的消息：转发给 iframe
+      if (event.data?.type === "assistantUIContext") {
+        if (cloudFrameReady && frame?.contentWindow) {
+          frame.contentWindow.postMessage(event.data, frameOrigin);
+        } else {
+          pendingFrameMessages.push(event.data);
+        }
+        return;
+      }
       if (event.data?.type === "quotaResult") {
         console.log("[iframe-wrapper] forwarding quotaResult to iframe", event.data);
         if (frame?.contentWindow) {
-          frame.contentWindow.postMessage(event.data, "*");
+          frame.contentWindow.postMessage(event.data, frameOrigin);
         }
       }
       if (event.data?.type === "theme") {
         if (frame?.contentWindow) {
-          frame.contentWindow.postMessage(event.data, "*");
+          frame.contentWindow.postMessage(event.data, frameOrigin);
         }
       }
     });

--- a/src/core/cs-cloud/extension/sidebarProvider.ts
+++ b/src/core/cs-cloud/extension/sidebarProvider.ts
@@ -7,6 +7,8 @@ import { getAssistantUIConfig, type AssistantUIConfig } from "./config"
 import { getAssistantUIStaticHtml, getAssistantUIIframeHtml, getAssistantUILoadingHtml } from "./html"
 import { CostrictAuthService } from "../../costrict/auth"
 import { CostrictAuthConfig } from "../../costrict/auth/authConfig"
+import type { AssistantUIContextMessage } from "./types"
+import { setActiveCloudProvider, onCloudUiReady, setCloudUnavailable } from "./contextBridge"
 
 export function getAssistantUIWorkspaceDirectory() {
 	return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
@@ -31,13 +33,56 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 		context.subscriptions.push(this.csCloudService)
 	}
 
+	/**
+	 * 向 Cloud UI webview 发送 context 消息。
+	 * 不直接暴露 private view 成员。
+	 */
+	public postContextMessage(message: AssistantUIContextMessage): Thenable<boolean> | undefined {
+		return this.view?.webview.postMessage(message)
+	}
+
 	async resolveWebviewView(webviewView: vscode.WebviewView) {
 		this.view = webviewView
+
+		// 注册为 active Cloud provider，获取当前 generation
+		const cloudGen = setActiveCloudProvider(this)
 
 		webviewView.webview.options = {
 			enableScripts: true,
 			localResourceRoots: [this.context.extensionUri],
 		}
+
+		// Handle dispose — 必须在所有 early return 之前注册
+		webviewView.onDidDispose(
+			() => {
+				this.view = undefined
+				setActiveCloudProvider(undefined)
+				this.dispose()
+			},
+			null,
+			this.disposables,
+		)
+
+		// Handle VS Code theme changes
+		vscode.window.onDidChangeActiveColorTheme(
+			(e) => {
+				const theme = e.kind === 1 || e.kind === 4 ? "light" : "dark"
+				webviewView.webview.postMessage({ type: "theme", theme })
+			},
+			null,
+			this.disposables,
+		)
+
+		// Handle visibility changes
+		webviewView.onDidChangeVisibility(
+			() => {
+				if (webviewView.visible) {
+					// Optional: refresh cs-cloud health or re-fetch state
+				}
+			},
+			null,
+			this.disposables,
+		)
 
 		// Handle messages from webview (e.g. openExternal from iframe)
 		webviewView.webview.onDidReceiveMessage(
@@ -49,6 +94,10 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 				token?: string
 				command?: string
 			}) => {
+				if (message.type === "ASSISTANT_UI_READY") {
+					onCloudUiReady(cloudGen)
+					return
+				}
 				if (message.type === "openExternal" && message.url) {
 					vscode.env.openExternal(vscode.Uri.parse(message.url))
 				}
@@ -67,7 +116,6 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 					await this.loadContent(webviewView)
 				}
 				if (message.type === "fetchQuota" && message.baseUrl && message.token) {
-					// console.log("[sidebarProvider] received fetchQuota, proxying to", message.baseUrl)
 					try {
 						const response = await fetch(`${message.baseUrl}/quota-manager/api/v1/quota`, {
 							headers: {
@@ -75,10 +123,8 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 								"Content-Type": "application/json",
 							},
 						})
-						// console.log("[sidebarProvider] quota response status", response.status)
 						if (response.ok) {
 							const json = await response.json()
-							// console.log("[sidebarProvider] posting quotaResult", json?.data)
 							webviewView.webview.postMessage({ type: "quotaResult", data: json?.data ?? null })
 						} else {
 							webviewView.webview.postMessage({ type: "quotaResult", data: null })
@@ -94,6 +140,7 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 		)
 		const config = getAssistantUIConfig()
 		if (!config.enabled) {
+			setCloudUnavailable("config disabled")
 			webviewView.webview.html = this.getDisabledHtml()
 			return
 		}

--- a/src/core/cs-cloud/extension/types.ts
+++ b/src/core/cs-cloud/extension/types.ts
@@ -1,0 +1,9 @@
+export interface AssistantUIContextMessage {
+	type: "assistantUIContext"
+	text: string // 插入 composer 的文本（如 "@path/file.ts:10-20"）
+	images?: string[] // base64 data URLs
+	previewText?: string // 仅用于 hover 预览，不插入 composer（与 Classic 行为一致）
+	focus?: boolean // 发送后是否聚焦 composer
+}
+
+export type SendContextResult = "sent" | "queued" | "unavailable"

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -90,6 +90,10 @@ import { OrganizationAllowListViolationError } from "../../utils/errors"
 
 import { setPanel } from "../../activate/registerCommands"
 
+import { getConfiguredUiMode } from "../../shared/uiMode"
+import type { AssistantUIContextMessage } from "../cs-cloud/extension/types"
+import { sendContextToCloudWithFocus } from "../cs-cloud/extension/contextBridge"
+
 import { t } from "../../i18n"
 
 // import { buildApiHandler } from "../../api"
@@ -903,6 +907,28 @@ export class ClineProvider
 		// Capture telemetry for code action usage
 		TelemetryService.instance.captureCodeActionUsed(promptType)
 
+		// Cloud 模式：不依赖 ClineProvider，提前分流
+		if (getConfiguredUiMode() === "cloud") {
+			if (command === "addToContext") {
+				const { pathOnly, selectedText } = supportPrompt.createPathWithSelectedText(
+					promptType as SupportPromptType,
+					params,
+					{},
+				)
+				const message: AssistantUIContextMessage = {
+					type: "assistantUIContext",
+					text: pathOnly.length > 0 ? `${pathOnly} ` : "",
+					previewText: selectedText,
+					focus: true,
+				}
+				await sendContextToCloudWithFocus(message)
+				return
+			}
+			// 其他 code action：目前 Cloud 不处理
+			return
+		}
+
+		// Classic 模式：现有逻辑不变
 		const visibleProvider = await ClineProvider.getInstance()
 
 		if (!visibleProvider) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ import { loadIdeaShellEnvOnce } from "./utils/ideaShellEnvLoader"
 import { isJetbrainsPlatform } from "./utils/platform"
 import { AssistantUISidebarProvider } from "./core/cs-cloud/extension/sidebarProvider"
 import { CsCloudService } from "./core/cs-cloud/extension/csCloudService"
-import { getConfiguredUiMode } from "./activate/registerCommands"
+import { getConfiguredUiMode } from "./shared/uiMode"
 // import { flushModels, getModels, initializeModelCacheRefresh } from "./api/providers/fetchers/modelCache"
 
 /**

--- a/src/shared/uiMode.ts
+++ b/src/shared/uiMode.ts
@@ -1,0 +1,25 @@
+import * as vscode from "vscode"
+import { Package } from "./package"
+
+export type UiMode = "classic" | "cloud"
+
+export const UI_MODE_OPTIONS: readonly { label: string; description: string; value: UiMode }[] = [
+	{ label: "Classic Mode", description: "Use the current CoStrict UI and logic", value: "classic" },
+	{ label: "Cloud Mode", description: "Use the Cloud UI on next launch", value: "cloud" },
+]
+
+export const getConfiguredUiMode = (): UiMode => {
+	const configured = vscode.workspace.getConfiguration(Package.commandIDPrefix).get<UiMode>("uiMode")
+	return configured === "cloud" ? "cloud" : "classic"
+}
+
+export const promptToReloadForUiModeChange = async () => {
+	const reloadNow = await vscode.window.showInformationMessage(
+		"UI mode updated. Reload Window to apply.",
+		"Reload Now",
+		"Later",
+	)
+	if (reloadNow === "Reload Now") {
+		await vscode.commands.executeCommand("workbench.action.reloadWindow")
+	}
+}


### PR DESCRIPTION
### Related GitHub Issue

Closes: # <!-- 本次变更无关联 Issue -->

### Description

在 Cloud UI 模式下增加 context bridge 支持，实现 add-to-context 和 code action 的上下文消息投递：

- 新建 `contextBridge.ts`：基于队列的 context 消息桥接层，处理 Cloud UI webview 的生命周期（provider 注册、ready 状态、unavailable 状态），支持 `sent`/`queued`/`unavailable` 三种投递结果
- 新建 `types.ts`：定义 `AssistantUIContextMessage` 和 `SendContextResult` 类型
- 新建 `shared/uiMode.ts`：将 `UiMode`、`getConfiguredUiMode`、`UI_MODE_OPTIONS` 从 `registerCommands.ts` 提取为共享模块
- `registerCommands.ts`：`addFileToContext` 增加 Cloud 模式提前分流，直接通过 contextBridge 发送消息而非依赖 ClineProvider
- `ClineProvider.ts`：code action `addToContext` 增加 Cloud 模式提前分流
- `sidebarProvider.ts`：集成 contextBridge 生命周期（setActiveCloudProvider、onCloudUiReady、setCloudUnavailable），调整 dispose/theme/visibility 事件注册顺序
- `html.ts`：static 和 iframe 模式下转发 `ASSISTANT_UI_READY` 消息，iframe 消息支持 readiness 队列缓冲
- `extension.ts`：更新 `getConfiguredUiMode` 导入路径

### Test Procedure

本地验证 Cloud 模式下 add-to-context 功能正常，classic 模式不受影响。

### Type of Change

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [ ] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Code Quality**:
    - [ ] My code adheres to the project's style guidelines.
    - [ ] There are no new linting errors or warnings (`npm run lint`).
    - [ ] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [ ] All tests pass locally (`npm test`).
    - [ ] The application builds successfully with my changes.
- [ ] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

N/A — 非 UI 变更。

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required.

### Additional Notes

BYPASS_HOOK=1