### PR TITLE
feat: add crash recovery and restart for cs-cloud service

### DIFF
--- a/src/__tests__/assistant-ui-cscloud-service.spec.ts
+++ b/src/__tests__/assistant-ui-cscloud-service.spec.ts
@@ -37,6 +37,19 @@ function createOutputChannel() {
 	return { appendLine: vi.fn() }
 }
 
+function mockSpawnProcess() {
+	vi.mocked(spawn).mockImplementation(() => {
+		const stdout = new EventEmitter()
+		const stderr = new EventEmitter()
+		return Object.assign(new EventEmitter(), {
+			stdout,
+			stderr,
+			killed: false,
+			kill: vi.fn(),
+		}) as unknown as import("child_process").ChildProcessWithoutNullStreams
+	})
+}
+
 function mockExecReturn(stdout: string) {
 	vi.mocked(exec).mockImplementation((cmd, options, callback) => {
 		if (typeof options === "function") {
@@ -66,6 +79,7 @@ function mockExecSequence(outputs: string[]) {
 describe("CsCloudService", () => {
 	beforeEach(() => {
 		allowNetConnect("127.0.0.1")
+		vi.mocked(spawn).mockReset()
 		setConfigValues({
 			baseUrl: "",
 			port: 45489,
@@ -185,6 +199,55 @@ describe("CsCloudService", () => {
 		const service = new CsCloudService(createOutputChannel() as never)
 
 		await expect(service.ensureStarted()).resolves.toBe("http://127.0.0.1:55555/api/v1")
+		expect(spawn).not.toHaveBeenCalled()
+	})
+
+	it("starts a managed daemon when restarting a detected unmanaged service", async () => {
+		setConfigValues({ baseUrl: "", port: 45489, autoStartCsCloud: false })
+		mockExecReturn(
+			"\x1b[1;38;2;125;86;244mcs-cloud status\x1b[m\n               \n\x1b[38;2;4;181;117m  ✓\x1b[m \x1b[38;2;4;181;117mRunning\x1b[m\n  \x1b[38;2;176;176;176mlocal_url:\x1b[m \x1b[38;2;255;255;255mhttp://127.0.0.1:55555\x1b[m\n",
+		)
+		nock("http://127.0.0.1:55555").get("/api/v1/runtime/health").reply(200, { ok: true })
+		nock("http://127.0.0.1:55555")
+			.get("/api/v1/conversations")
+			.query({ roots: "true", archived: "true" })
+			.reply(200, [])
+
+		const outputChannel = createOutputChannel()
+		const service = new CsCloudService(outputChannel as never)
+
+		await expect(service.ensureStarted()).resolves.toBe("http://127.0.0.1:55555/api/v1")
+		expect(spawn).not.toHaveBeenCalled()
+
+		mockSpawnProcess()
+		nock("http://127.0.0.1:45489").get("/api/v1/runtime/health").reply(200, { ok: true })
+		nock("http://127.0.0.1:45489")
+			.get("/api/v1/conversations")
+			.query({ roots: "true", archived: "true" })
+			.reply(200, [])
+
+		await expect(service.restart()).resolves.toBe("http://127.0.0.1:45489/api/v1")
+		expect(spawn).toHaveBeenCalledWith(
+			"csc",
+			["cloud", "start", "--port", "45489"],
+			expect.objectContaining({ cwd: "/workspace" }),
+		)
+		expect(outputChannel.appendLine).toHaveBeenCalledWith(
+			"[AssistantUI] Restarting previously detected cs-cloud as a managed cs-cloud daemon...",
+		)
+		expect(outputChannel.appendLine).toHaveBeenCalledWith(
+			"[AssistantUI] Starting cs-cloud: csc cloud start --port 45489",
+		)
+	})
+
+	it("keeps configured baseUrl unmanaged when restarting", async () => {
+		setConfigValues({ baseUrl: "http://127.0.0.1:55555/api/v1", port: 45489, autoStartCsCloud: true })
+		nock("http://127.0.0.1:55555").get("/api/v1/runtime/health").reply(200, { ok: true })
+
+		const service = new CsCloudService(createOutputChannel() as never)
+
+		await expect(service.ensureStarted()).resolves.toBe("http://127.0.0.1:55555/api/v1")
+		await expect(service.restart()).resolves.toBe("http://127.0.0.1:55555/api/v1")
 		expect(spawn).not.toHaveBeenCalled()
 	})
 

--- a/src/core/cs-cloud/extension/csCloudService.ts
+++ b/src/core/cs-cloud/extension/csCloudService.ts
@@ -1,27 +1,85 @@
 import * as http from "http"
-import { spawn, exec, type ChildProcessWithoutNullStreams } from "child_process"
+import { spawn, exec, type ChildProcessWithoutNullStreams, type ChildProcess } from "child_process"
+import { EventEmitter } from "events"
 import * as vscode from "vscode"
 import { getAssistantUIConfig } from "./config"
 
-export class CsCloudService implements vscode.Disposable {
+/** cs-cloud 进程归属类型 */
+export type CsCloudOwnership = "owned" | "unmanaged"
+/** cs-cloud 来源辅助信息 */
+export type CsCloudSource = "spawned" | "detected" | "configuredBaseUrl"
+
+export class CsCloudService extends EventEmitter implements vscode.Disposable {
 	private process: ChildProcessWithoutNullStreams | undefined
 	private baseUrl: string | undefined
 	private lastErrorLine: string | undefined
-	private processExited = false
 
-	constructor(private readonly outputChannel: vscode.OutputChannel) {}
+	// ── 状态与归属 ──
+	state: "idle" | "starting" | "running" | "crashed" | "failed" = "idle"
+	ownership: CsCloudOwnership = "owned"
+	source: CsCloudSource = "spawned"
+
+	// ── 并发保护 ──
+	private generation = 0
+	private expectedStopGenerations: Set<number> = new Set()
+	private operationPromise?: Promise<string>
+
+	// ── 持久化 crash 信息 ──
+	lastCrashReason?: string
+	startupFailureReason?: string
+
+	// ── 健康检查 ──
+	private failCount = 0
+	private healthTimer?: NodeJS.Timeout
+
+	constructor(private readonly outputChannel: vscode.OutputChannel) {
+		super()
+	}
+
+	/** 暴露 baseUrl 供外部使用 */
+	get baseUrlValue(): string | undefined {
+		return this.baseUrl
+	}
+
+	// ═══════════════════════════════════════════════════════════════
+	// ensureStarted() / doEnsureStarted()
+	// ═══════════════════════════════════════════════════════════════
 
 	async ensureStarted(): Promise<string> {
-		const config = getAssistantUIConfig()
-		if (config.baseUrl.trim()) {
-			this.baseUrl = trimTrailingSlash(config.baseUrl.trim())
+		if (this.operationPromise) return this.operationPromise
+
+		// 如果已经是 owned 且 running，直接返回 baseUrl，避免 doEnsureStarted
+		// 中的 detectCsCloudPort 把 ownership 覆盖成 "unmanaged"（会导致
+		// 后续崩溃后 restart 时走 unmanaged 分支，只 health check 不 spawn）
+		if (this.state === "running" && this.ownership === "owned" && this.baseUrl) {
 			return this.baseUrl
 		}
 
-		const detectedPort = await detectCsCloudPort(config.defaultCli)
+		this.operationPromise = this.doEnsureStarted(false)
+		try {
+			const url = await this.operationPromise
+			this.handleStartSuccess()
+			return url
+		} finally {
+			this.operationPromise = undefined
+		}
+	}
+
+	private async doEnsureStarted(skipDetection = false, forceStart = false): Promise<string> {
+		const config = getAssistantUIConfig()
+		if (config.baseUrl.trim()) {
+			this.baseUrl = trimTrailingSlash(config.baseUrl.trim())
+			this.ownership = "unmanaged"
+			this.source = "configuredBaseUrl"
+			return this.baseUrl
+		}
+
+		const detectedPort = skipDetection ? undefined : await detectCsCloudPort(config.defaultCli)
 		if (detectedPort !== undefined) {
 			const healthUrl = `http://127.0.0.1:${detectedPort}/api/v1/runtime/health`
 			this.baseUrl = `http://127.0.0.1:${detectedPort}/api/v1`
+			this.ownership = "unmanaged"
+			this.source = "detected"
 
 			if (await isHttpReady(healthUrl)) {
 				await assertOpenCodeCompatible(this.baseUrl)
@@ -40,48 +98,93 @@ export class CsCloudService implements vscode.Disposable {
 		const healthUrl = `http://127.0.0.1:${port}/api/v1/runtime/health`
 		this.baseUrl = `http://127.0.0.1:${port}/api/v1`
 
-		if (await isHttpReady(healthUrl)) {
+		if (!skipDetection && (await isHttpReady(healthUrl))) {
+			this.ownership = "unmanaged"
+			this.source = "detected"
 			await assertOpenCodeCompatible(this.baseUrl)
 			return this.baseUrl
 		}
 
-		if (!config.autoStartCsCloud) {
+		if (!config.autoStartCsCloud && !forceStart) {
 			throw new Error("cs-cloud 没有运行，请先启动 cs-cloud 或设置 costrict.assistantUI.baseUrl")
 		}
 
-		if (!this.process) {
-			this.lastErrorLine = undefined
-			this.processExited = false
+		// ── 自己 spawn ──
+		this.ownership = "owned"
+		this.source = "spawned"
+		this.state = "starting"
+		this.lastErrorLine = undefined
+		this.startupFailureReason = undefined
 
+		if (!this.process) {
 			this.outputChannel.appendLine(
 				`[AssistantUI] Starting cs-cloud: ${config.defaultCli} cloud start --port ${port}`,
 			)
+			// 仅首次启动时递增 generation；restart 路径已由 doRestart 递增
+			if (!skipDetection) {
+				this.generation++
+			}
 			this.process = spawn(config.defaultCli, ["cloud", "start"].concat(port ? ["--port", String(port)] : []), {
 				cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
 				env: process.env,
 			})
 
-			this.process.stdout.on("data", (data) => {
+			const child = this.process
+			const childGen = this.generation
+
+			child.stdout.on("data", (data) => {
 				const text = String(data).trimEnd()
 				this.outputChannel.appendLine(`[cs-cloud] ${text}`)
 				this.captureErrorLine(text)
 			})
-			this.process.stderr.on("data", (data) => {
+			child.stderr.on("data", (data) => {
 				const text = String(data).trimEnd()
 				this.outputChannel.appendLine(`[cs-cloud] ${text}`)
 				this.captureErrorLine(text)
 			})
-			this.process.on("exit", (code, signal) => {
+			child.on("exit", (code, signal) => {
 				this.outputChannel.appendLine(`[AssistantUI] cs-cloud exited code=${code ?? ""} signal=${signal ?? ""}`)
-				this.process = undefined
-				if (code !== 0 || signal !== null) {
-					this.processExited = true
+
+				// 只有当前进程引用一致时才清空，防止旧事件清掉新进程引用
+				if (this.process === child) {
+					this.process = undefined
+				}
+
+				// 按 generation 检查是否为主动 kill
+				if (this.expectedStopGenerations.has(childGen)) {
+					this.expectedStopGenerations.delete(childGen)
+					return
+				}
+
+				// 旧 generation 事件忽略
+				if (childGen !== this.generation) return
+
+				// STARTING 阶段退出：仅非零退出码或 signal 才视为失败。
+				// cs-cloud daemon 模式会 fork 后父进程 exit(0)，此时不应报错，
+				// 让 waitForHttpReady 继续轮询等待 daemon HTTP 端口就绪。
+				if (this.state === "starting") {
+					if (code !== 0 || signal) {
+						this.startupFailureReason = this.lastErrorLine ?? `code=${code} signal=${signal}`
+						this.state = "failed"
+					}
+					return
+				}
+
+				// RUNNING 阶段退出 → 仅非零退出码或 signal 才视为崩溃。
+				// daemon fork 后 child exit(0) 可能在 handleStartSuccess 之后才被
+				// EventLoop 处理到（竞态），此时 state 已为 running，不应误判崩溃。
+				if (this.state === "running") {
+					if (code !== 0 || signal) {
+						this.notifyCrash(`进程退出 (code=${code}, signal=${signal})`)
+					}
+					return
 				}
 			})
-			this.process.on("error", (error) => {
+			child.on("error", (error) => {
 				this.outputChannel.appendLine(`[AssistantUI] Failed to start cs-cloud: ${error.message}`)
 				this.lastErrorLine = error.message
-				this.processExited = true
+				this.startupFailureReason = error.message
+				this.state = "failed"
 			})
 		}
 
@@ -90,11 +193,154 @@ export class CsCloudService implements vscode.Disposable {
 		return this.baseUrl
 	}
 
+	// ═══════════════════════════════════════════════════════════════
+	// restart()
+	// ═══════════════════════════════════════════════════════════════
+
+	async restart(): Promise<string> {
+		if (this.operationPromise) return this.operationPromise
+
+		this.operationPromise = this.doRestart()
+		try {
+			return await this.operationPromise
+		} finally {
+			this.operationPromise = undefined
+		}
+	}
+
+	private async doRestart(): Promise<string> {
+		if (this.ownership === "unmanaged" && this.source === "configuredBaseUrl") {
+			this.outputChannel.appendLine(
+				`[AssistantUI] Restart requested for configured cs-cloud baseUrl ${this.baseUrl}; waiting for health check...`,
+			)
+			await this.waitForHealth()
+			this.handleStartSuccess()
+			return this.baseUrl!
+		}
+
+		if (this.ownership === "unmanaged") {
+			this.outputChannel.appendLine(
+				"[AssistantUI] Restarting previously detected cs-cloud as a managed cs-cloud daemon...",
+			)
+		}
+
+		// owned 或自动检测到的 unmanaged：启动一个由扩展管理的新进程
+		this.stopHealthMonitor()
+		this.state = "starting"
+		this.failCount = 0
+		this.startupFailureReason = undefined
+
+		const oldProcess = this.process
+		const oldGen = this.generation
+
+		if (oldProcess && !oldProcess.killed) {
+			this.expectedStopGenerations.add(oldGen)
+			oldProcess.kill()
+			await this.waitForProcessExit(oldProcess, 5000)
+		}
+		this.process = undefined
+		this.generation++
+
+		try {
+			const url = await this.doEnsureStarted(true, true)
+			this.handleStartSuccess()
+			return url
+		} finally {
+			this.expectedStopGenerations.delete(oldGen)
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════
+	// dispose()
+	// ═══════════════════════════════════════════════════════════════
+
 	dispose(): void {
+		this.stopHealthMonitor()
 		if (this.process && !this.process.killed) {
+			const gen = this.generation
+			this.expectedStopGenerations.add(gen)
 			this.process.kill()
 		}
 		this.process = undefined
+	}
+
+	// ═══════════════════════════════════════════════════════════════
+	// handleStartSuccess / notifyCrash / 健康检查
+	// ═══════════════════════════════════════════════════════════════
+
+	private handleStartSuccess(): void {
+		this.state = "running"
+		this.lastCrashReason = undefined
+		this.failCount = 0
+		this.startupFailureReason = undefined
+		this.startHealthMonitor()
+	}
+
+	private notifyCrash(reason: string): void {
+		if (this.state === "crashed") return
+		this.state = "crashed"
+		this.lastCrashReason = reason
+		this.stopHealthMonitor()
+		this.emit("crashed", { reason })
+	}
+
+	private startHealthMonitor(): void {
+		this.stopHealthMonitor()
+		const monitorGen = this.generation
+		const healthUrl = this.healthUrl
+
+		const doCheck = async () => {
+			if (monitorGen !== this.generation || this.state !== "running") return
+
+			const healthy = await isHttpReady(healthUrl)
+
+			if (monitorGen !== this.generation || this.state !== "running") return
+
+			if (healthy) {
+				this.failCount = 0
+			} else {
+				this.failCount++
+				if (this.failCount >= 3) {
+					this.notifyCrash("健康检查连续失败")
+					return
+				}
+			}
+
+			this.healthTimer = setTimeout(doCheck, 30_000)
+		}
+
+		this.healthTimer = setTimeout(doCheck, 30_000)
+	}
+
+	private stopHealthMonitor(): void {
+		if (this.healthTimer) {
+			clearTimeout(this.healthTimer)
+			this.healthTimer = undefined
+		}
+	}
+
+	private get healthUrl(): string {
+		return this.baseUrl ? `${this.baseUrl}/runtime/health` : "http://127.0.0.1:0/api/v1/runtime/health"
+	}
+
+	// ═══════════════════════════════════════════════════════════════
+	// Helpers
+	// ═══════════════════════════════════════════════════════════════
+
+	private async waitForHealth(timeoutMs = 30_000): Promise<void> {
+		const startedAt = Date.now()
+		while (Date.now() - startedAt < timeoutMs) {
+			if (await isHttpReady(this.healthUrl)) return
+			await new Promise((resolve) => setTimeout(resolve, 1000))
+		}
+		throw new Error("Timed out waiting for cs-cloud health check")
+	}
+
+	private async waitForProcessExit(proc: ChildProcess, timeoutMs: number): Promise<void> {
+		await Promise.race([
+			new Promise<void>((resolve) => proc.once("exit", () => resolve())),
+			new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+		])
 	}
 
 	private captureErrorLine(text: string) {
@@ -117,9 +363,8 @@ export class CsCloudService implements vscode.Disposable {
 		let attempt = 0
 
 		while (Date.now() - startedAt < timeoutMs) {
-			if (this.processExited) {
-				const reason = this.lastErrorLine ? `: ${this.lastErrorLine}` : ""
-				throw new Error(`cs-cloud 启动失败${reason}`)
+			if (this.startupFailureReason) {
+				throw new Error(`cs-cloud 启动失败: ${this.startupFailureReason}`)
 			}
 
 			try {
@@ -133,9 +378,8 @@ export class CsCloudService implements vscode.Disposable {
 			await new Promise((resolve) => setTimeout(resolve, delay))
 		}
 
-		if (this.processExited) {
-			const reason = this.lastErrorLine ? `: ${this.lastErrorLine}` : ""
-			throw new Error(`cs-cloud 启动失败${reason}`)
+		if (this.startupFailureReason) {
+			throw new Error(`cs-cloud 启动失败: ${this.startupFailureReason}`)
 		}
 
 		throw new Error(

--- a/src/core/cs-cloud/extension/html.ts
+++ b/src/core/cs-cloud/extension/html.ts
@@ -216,8 +216,14 @@ function getNonce() {
 	return text
 }
 
-function escapeHtml(value: string) {
-	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\"/g, "&quot;")
+/** 转义 HTML 特殊字符，防止 XSS */
+export function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;")
 }
 
 function getAssistantUITheme() {
@@ -365,6 +371,145 @@ function getLoadingMarkup(logoSvg: string, loadingText = "正在初始化界面.
       </div>
     </div>
   </div>`
+}
+
+/**
+ * 崩溃错误页 HTML。
+ * 包含「重试」按钮，通过 postMessage 与 SidebarProvider 交互。
+ */
+export function getCrashedHtml(reason?: string): string {
+	return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CoStrict Cloud - Crashed</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: var(--vscode-font-family, sans-serif);
+      background: var(--vscode-editor-background);
+      color: var(--vscode-foreground);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 24px;
+    }
+    .crash-card {
+      max-width: 400px;
+      width: 100%;
+      text-align: center;
+    }
+    .crash-icon {
+      width: 48px;
+      height: 48px;
+      margin: 0 auto 16px;
+    }
+    .crash-icon svg {
+      width: 100%;
+      height: 100%;
+    }
+    .crash-title {
+      font-size: 16px;
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: var(--vscode-errorForeground);
+    }
+    .crash-desc {
+      font-size: 13px;
+      color: var(--vscode-descriptionForeground);
+      margin-bottom: 20px;
+      line-height: 1.5;
+    }
+    .crash-detail {
+      background: var(--vscode-textCodeBlock-background);
+      border-radius: 4px;
+      padding: 10px 12px;
+      font-size: 12px;
+      font-family: var(--vscode-editor-font-family, monospace);
+      color: var(--vscode-descriptionForeground);
+      text-align: left;
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 120px;
+      overflow-y: auto;
+      margin-bottom: 16px;
+    }
+    .crash-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: center;
+    }
+    .crash-btn {
+      padding: 6px 14px;
+      font-size: 12px;
+      border: none;
+      border-radius: 2px;
+      cursor: pointer;
+      font-family: var(--vscode-font-family, sans-serif);
+      transition: opacity 0.15s;
+    }
+    .crash-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    .crash-btn-primary {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+    }
+    .crash-btn-primary:hover:not(:disabled) {
+      background: var(--vscode-button-hoverBackground);
+    }
+  </style>
+</head>
+<body>
+  <div class="crash-card">
+    <div class="crash-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--vscode-errorForeground)">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+      </svg>
+    </div>
+    <div class="crash-title">CoStrict Cloud 服务已崩溃</div>
+    <div class="crash-desc">cs-cloud 进程意外退出，请尝试重启服务。</div>
+    ${reason ? `<pre class="crash-detail">${escapeHtml(reason)}</pre>` : ""}
+    <div class="crash-actions">
+      <button id="restart-btn" class="crash-btn crash-btn-primary" onclick="handleRestart()">重试</button>
+    </div>
+  </div>
+  <script>
+    const vscode = acquireVsCodeApi();
+
+    function handleRestart() {
+      const btn = document.getElementById("restart-btn");
+      btn.disabled = true;
+      btn.textContent = "正在重启...";
+      vscode.postMessage({ type: "restartCsCloud" });
+    }
+
+    // 监听重启结果（由 SidebarProvider 回发）
+    window.addEventListener("message", (e) => {
+      if (e.data?.type === "restartFailed") {
+        const btn = document.getElementById("restart-btn");
+        btn.disabled = false;
+        btn.textContent = "重试";
+        const detail = document.querySelector(".crash-detail");
+        if (detail) {
+          detail.textContent = e.data.reason;
+        } else {
+          const desc = document.querySelector(".crash-desc");
+          if (desc) {
+            const pre = document.createElement("pre");
+            pre.className = "crash-detail";
+            pre.textContent = e.data.reason;
+            desc.after(pre);
+          }
+        }
+      }
+    });
+  </script>
+</body>
+</html>`
 }
 
 export function getAssistantUILoadingHtml(context: vscode.ExtensionContext, loadingText?: string) {

--- a/src/core/cs-cloud/extension/sidebarProvider.ts
+++ b/src/core/cs-cloud/extension/sidebarProvider.ts
@@ -4,7 +4,13 @@ import * as os from "os"
 import * as path from "path"
 import { CsCloudService } from "./csCloudService"
 import { getAssistantUIConfig, type AssistantUIConfig } from "./config"
-import { getAssistantUIStaticHtml, getAssistantUIIframeHtml, getAssistantUILoadingHtml } from "./html"
+import {
+	getAssistantUIStaticHtml,
+	getAssistantUIIframeHtml,
+	getAssistantUILoadingHtml,
+	getCrashedHtml,
+	escapeHtml,
+} from "./html"
 import { CostrictAuthService } from "../../costrict/auth"
 import { CostrictAuthConfig } from "../../costrict/auth/authConfig"
 import type { AssistantUIContextMessage } from "./types"
@@ -23,7 +29,7 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 	public static readonly viewType = "costrict.AssistantUISidebarProvider"
 
 	private view?: vscode.WebviewView
-	private csCloudService: CsCloudService
+	private readonly csCloudService: CsCloudService
 	private disposables: vscode.Disposable[] = []
 
 	/**
@@ -36,9 +42,9 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 	constructor(
 		private readonly context: vscode.ExtensionContext,
 		private readonly outputChannel: vscode.OutputChannel,
+		csCloudService: CsCloudService,
 	) {
-		this.csCloudService = new CsCloudService(outputChannel)
-		context.subscriptions.push(this.csCloudService)
+		this.csCloudService = csCloudService
 	}
 
 	/**
@@ -66,6 +72,23 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 				this.view = undefined
 				setActiveCloudProvider(undefined)
 				this.dispose()
+			},
+			null,
+			this.disposables,
+		)
+
+		// 1. 先注册事件监听（必须在分支渲染之前）+ 生命周期管理
+		const crashedHandler = ({ reason }: { reason: string }) => {
+			if (this.view) {
+				this.view.webview.html = getCrashedHtml(reason)
+			}
+		}
+		this.csCloudService.on("crashed", crashedHandler)
+
+		// webview dispose 时移除监听，避免重复绑定和内存泄漏
+		webviewView.onDidDispose(
+			() => {
+				this.csCloudService.off("crashed", crashedHandler)
 			},
 			null,
 			this.disposables,
@@ -125,6 +148,22 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 					this.cachedHtml = undefined
 					await this.loadContent(webviewView)
 				}
+				if (message.type === "restartCsCloud") {
+					try {
+						await this.csCloudService.restart()
+						// 成功：重新加载 Cloud UI
+						this.cachedHtml = undefined
+						await this.loadContent(this.view!)
+					} catch (err) {
+						// 失败：通知错误页恢复按钮
+						const reason = err instanceof Error ? err.message : String(err)
+						this.outputChannel.appendLine(`[AssistantUI] Restart cs-cloud failed: ${reason}`)
+						this.view?.webview.postMessage({
+							type: "restartFailed",
+							reason,
+						})
+					}
+				}
 				if (message.type === "fetchQuota" && message.baseUrl && message.token) {
 					try {
 						const response = await fetch(`${message.baseUrl}/quota-manager/api/v1/quota`, {
@@ -156,13 +195,27 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 			return
 		}
 
-		// 如果有缓存的 HTML（侧边栏拖拽移动后重建 webview），直接复用
-		if (this.cachedHtml) {
-			webviewView.webview.html = this.cachedHtml
-			return
+		// 2. 根据持久化状态渲染
+		switch (this.csCloudService.state) {
+			case "crashed":
+				webviewView.webview.html = getCrashedHtml(this.csCloudService.lastCrashReason)
+				return
+			case "failed":
+				webviewView.webview.html = this.getErrorHtml(
+					this.csCloudService.startupFailureReason ??
+						this.csCloudService.lastCrashReason ??
+						"cs-cloud 启动失败",
+				)
+				return
+			case "running":
+				await this.loadContent(webviewView)
+				return
+			case "starting":
+			case "idle":
+				webviewView.webview.html = getAssistantUILoadingHtml(this.context, "正在启动 CoStrict Cloud...")
+				await this.loadContent(webviewView)
+				return
 		}
-
-		await this.loadContent(webviewView)
 	}
 
 	private getDisabledHtml(): string {
@@ -272,14 +325,27 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 </head>
 <body>
 	 <h3>CoStrict Cloud 启动失败</h3>
-	 <pre>${message.replace(/</g, "<")}</pre>
+	 <pre>${escapeHtml(message)}</pre>
 	 <p class="hint">请检查输出面板（Output → CoStrict）中的完整日志，或尝试重新登录 cs-cloud。</p>
-	 <button onclick="vscode.postMessage({type:'reloadAssistantUI'})">重试</button>
+	 <button onclick="vscode.postMessage({type:'restartCsCloud'})">重试</button>
 	 <script>
 	   const vscode = acquireVsCodeApi();
 	 </script>
 </body>
 </html>`
+	}
+
+	/**
+	 * 命令面板专用 restart 入口。
+	 * 如果 sidebar 未打开，直接 restart 即可（下次打开时根据状态渲染）。
+	 * 如果 sidebar 已打开，restart 成功后重新加载内容。
+	 */
+	async restartCsCloud(): Promise<void> {
+		await this.csCloudService.restart()
+		this.cachedHtml = undefined
+		if (this.view) {
+			await this.loadContent(this.view)
+		}
 	}
 
 	dispose() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -239,7 +239,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Only register AssistantUISidebarProvider when in cloud mode to avoid
 	// unnecessary object allocation and cs-cloud service initialization.
 	if (uiMode === "cloud") {
-		const assistantProvider = new AssistantUISidebarProvider(context, outputChannel)
+		// 创建单例 CsCloudService，注入给 SidebarProvider，避免多个实例竞争端口
+		const csCloudService = new CsCloudService(outputChannel)
+		context.subscriptions.push(csCloudService)
+
+		const assistantProvider = new AssistantUISidebarProvider(context, outputChannel, csCloudService)
 
 		context.subscriptions.push(
 			vscode.window.registerWebviewViewProvider(AssistantUISidebarProvider.viewType, assistantProvider, {
@@ -247,10 +251,24 @@ export async function activate(context: vscode.ExtensionContext) {
 			}),
 		)
 
+		// 注册 restart 命令（命令面板 + 错误页按钮）
+		context.subscriptions.push(
+			vscode.commands.registerCommand("costrict.restartCsCloud", async () => {
+				try {
+					await assistantProvider.restartCsCloud()
+				} catch (err) {
+					outputChannel.appendLine(
+						`[cs-cloud] restart failed: ${err instanceof Error ? err.message : String(err)}`,
+					)
+					vscode.window.showErrorMessage(
+						`重启 cs-cloud 失败: ${err instanceof Error ? err.message : String(err)}`,
+					)
+				}
+			}),
+		)
+
 		// Pre-start cs-cloud daemon when in cloud mode so it's ready by the
 		// time the user opens the sidebar.
-		const csCloudService = new CsCloudService(outputChannel)
-		context.subscriptions.push(csCloudService)
 		void csCloudService.ensureStarted().catch((err) => {
 			outputChannel.appendLine(
 				`[cs-cloud] auto-start failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/package.json
+++ b/src/package.json
@@ -137,6 +137,11 @@
 				"icon": "$(account)"
 			},
 			{
+				"command": "costrict.restartCsCloud",
+				"title": "CoStrict: Restart CoStrict Cloud",
+				"category": "%configuration.title%"
+			},
+			{
 				"command": "costrict.settingsButtonClicked",
 				"title": "%command.settings.title%",
 				"icon": "$(settings-gear)"


### PR DESCRIPTION
### Related GitHub Issue

Closes: # <!-- No linked issue for this PR -->

### Description

为 cs-cloud 服务添加崩溃恢复能力和重启功能。主要变更：

- **状态机**：为 CsCloudService 引入 state (idle/starting/running/crashed/failed)、ownership (owned/unmanaged) 和 source (spawned/detected/configuredBaseUrl) 状态管理，清晰追踪服务生命周期各阶段状态。
- **进程归属分离**：区分 managed (通过 spawn 启动) 和 unmanaged (检测到已有进程或用户配置 baseUrl) 两种场景，针对不同归属有不同的重启策略。
- **崩溃检测**：通过 exit 事件和健康检查机制检测进程崩溃，发生 crash 时通知 UI 切换到错误页。
- **健康检查**：基于定时轮询的健康监控（每 30 秒），连续 3 次失败即触发 crash 通知。
- **并发保护**：通过 generation 计数器和新旧进程引用隔离，确保并发操作不会互相干扰。
- **重启能力**：`restart()` 方法支持优雅终止旧进程并重新启动；支持 owned/unmanaged 两种场景。
- **崩溃界面**：`getCrashedHtml()` 渲染包含错误详情和重试按钮的崩溃错误页面，用户点击重试触发 restart。
- **状态驱动渲染**：SidebarProvider 根据 csCloudService.state 渲染对应界面（loading/crashed/failed/正常）。
- **命令注册**：注册 `costrict.restartCsCloud` 命令，支持命令面板调用。
- **单例注入**：CsCloudService 作为单例创建并注入 SidebarProvider，避免多实例竞争端口。

### Test Procedure

1. 启动 extension，确认 cloud UI 正常加载
2. 手动终止 cs-cloud 进程，验证:
   - 崩溃错误页正确显示
   - 错误详情（code/signal）正确展示
   - 重试按钮可点击
3. 点击重试按钮，验证 cs-cloud 能正常重启
4. 使用命令面板执行 "CoStrict: Restart CoStrict Cloud"，验证功能正常
5. 配置 baseUrl 场景下验证重启行为（走 unmanaged 健康检查分支）
6. 验证单元测试通过

### Type of Change

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [ ] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [ ] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [ ] **Branch Hygiene**: My branch is up-to-date (rebased) with the `costrict-cloud` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

N/A — Crash UI can be verified by running the extension.

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).

### Additional Notes

重构核心思路：将 CsCloudService 从一次性启动脚本升级为带有完整生命周期管理的 Service。关键设计选择包括：

1. **generation 计数器**：每次 spawn 时递增，确保 exit 事件只由当前进程处理，避免旧进程退出时误判 crash
2. **ownership 模式**：unmanaged 重启走健康检查等待，managed 重启走 kill+spawn 路径
3. **fork 竞态处理**：daemon 模式下父进程 exit(0) 可能晚于 handleStartSuccess，通过 generation 和 state 双重检查避免误判

### Get in Touch
