### PR TITLE
fix: add getConfiguration mock to registerCommands spec

### DIFF
--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -51,6 +51,9 @@ vi.mock("vscode", async () => {
 				stat: vi.fn(),
 			},
 			getWorkspaceFolder: vi.fn(),
+			getConfiguration: vi.fn().mockReturnValue({
+				get: vi.fn().mockReturnValue("classic"),
+			}),
 			createFileSystemWatcher: vi.fn().mockReturnValue({
 				onDidCreate: vi.fn().mockReturnValue({ dispose: vi.fn() }),
 				onDidChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),


### PR DESCRIPTION
### Related GitHub Issue

Closes: #

### Description

在 registerCommands 测试中添加了 `getConfiguration` 的 mock 实现，修复测试中因缺少该配置项导致的问题。

### Test Procedure

本地验证功能正常。

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see above).
- [x] **Scope**: My changes are focused on the linked issue.
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**: My code adheres to the project's style guidelines.
- [x] **Branch Hygiene**: My branch is up-to-date with the `costrict-cloud` branch.

### Screenshots / Videos

N/A — this is a test infrastructure change, not a UI change.

### Get in Touch

