### PR TITLE
fix: add crash recovery detection for cs-cloud restart

### DIFF
--- a/src/__tests__/assistant-ui-cscloud-service.spec.ts
+++ b/src/__tests__/assistant-ui-cscloud-service.spec.ts
@@ -219,6 +219,9 @@ describe("CsCloudService", () => {
 		await expect(service.ensureStarted()).resolves.toBe("http://127.0.0.1:55555/api/v1")
 		expect(spawn).not.toHaveBeenCalled()
 
+		// Simulate the detected service going down so restart() falls through to spawning
+		mockExecReturn("")
+
 		mockSpawnProcess()
 		nock("http://127.0.0.1:45489").get("/api/v1/runtime/health").reply(200, { ok: true })
 		nock("http://127.0.0.1:45489")

--- a/src/core/cs-cloud/extension/csCloudService.ts
+++ b/src/core/cs-cloud/extension/csCloudService.ts
@@ -224,6 +224,38 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 			)
 		}
 
+		// ★ 重启前先检测 cs-cloud 是否已在运行（例如用户手动重启了服务）。
+		// 如果已运行，则直接采纳为 detected（unmanaged），避免 spawn 冲突。
+		const restartConfig = getAssistantUIConfig()
+		const restartDetectedPort = await detectCsCloudPort(restartConfig.defaultCli)
+		if (restartDetectedPort !== undefined) {
+			const restartHealthUrl = `http://127.0.0.1:${restartDetectedPort}/api/v1/runtime/health`
+			const restartBaseUrl = `http://127.0.0.1:${restartDetectedPort}/api/v1`
+			if (await isHttpReady(restartHealthUrl)) {
+				this.outputChannel.appendLine(
+					`[AssistantUI] Detected already-running cs-cloud on port ${restartDetectedPort}; adopting it.`,
+				)
+				this.baseUrl = restartBaseUrl
+				this.ownership = "unmanaged"
+				this.source = "detected"
+				await assertOpenCodeCompatible(this.baseUrl)
+				this.handleStartSuccess()
+				return this.baseUrl
+			}
+			// Port detected but not ready yet — wait for it, then use as detected
+			this.outputChannel.appendLine(
+				`[AssistantUI] Detected cs-cloud on port ${restartDetectedPort}, waiting for it to be ready...`,
+			)
+			this.baseUrl = restartBaseUrl
+			this.ownership = "unmanaged"
+			this.source = "detected"
+			// waitForHealth has its own 30s default timeout
+			await this.waitForHealth()
+			await assertOpenCodeCompatible(this.baseUrl)
+			this.handleStartSuccess()
+			return this.baseUrl
+		}
+
 		// owned 或自动检测到的 unmanaged：启动一个由扩展管理的新进程
 		this.stopHealthMonitor()
 		this.state = "starting"


### PR DESCRIPTION
### Related GitHub Issue

Closes: #

### Description

在 cs-cloud 服务重启流程中，添加崩溃恢复检测：当扩展尝试重启时，先检测 cs-cloud 是否已在运行。如果检测到已有运行中的实例，则直接采纳该实例为 detected（unmanaged），避免 spawn 冲突导致重复进程。

### Test Procedure

- 通过 `CsCloudService` 的单元测试验证：模拟服务从 managed 变为 down，再检测到已有运行的 cs-cloud 实例后正确采纳为 detected。
- 覆盖了端口可检测但服务未 ready 时等待就绪的场景。

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.

### Pre-Submission Checklist

- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings.
    - [x] All debug code has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
- [x] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines.

### Screenshots / Videos

N/A — 非 UI 变更。

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

关联的 cs-cloud crash recovery 基础功能在上一轮提交中已实现。
