### PR TITLE
fix: increase cs-cloud health check timeout to 60s

### DIFF
--- a/src/core/cs-cloud/extension/csCloudService.ts
+++ b/src/core/cs-cloud/extension/csCloudService.ts
@@ -93,7 +93,7 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 			this.outputChannel.appendLine(
 				`[AssistantUI] Detected cs-cloud on port ${detectedPort}, waiting for it to be ready...`,
 			)
-			await this.waitForHttpReady(healthUrl, 15_000)
+			await this.waitForHttpReady(healthUrl, 60_000)
 			await assertOpenCodeCompatible(this.baseUrl)
 			return this.baseUrl
 		}
@@ -197,7 +197,7 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 			})
 		}
 
-		await this.waitForHttpReady(healthUrl, 15_000)
+		await this.waitForHttpReady(healthUrl, 60_000)
 		await assertOpenCodeCompatible(this.baseUrl)
 		return this.baseUrl
 	}
@@ -357,7 +357,7 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 	// Helpers
 	// ═══════════════════════════════════════════════════════════════
 
-	private async waitForHealth(timeoutMs = 30_000): Promise<void> {
+	private async waitForHealth(timeoutMs = 60_000): Promise<void> {
 		const startedAt = Date.now()
 		while (Date.now() - startedAt < timeoutMs) {
 			if (await isHttpReady(this.healthUrl)) return


### PR DESCRIPTION
### Related GitHub Issue

Closes: #

### Description

将 cs-cloud 服务健康检查超时时间从 15s/30s 统一增加到 60s，避免在网络较慢或服务启动较慢的场景下因超时导致服务不可用。

### Test Procedure

本地验证功能正常

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

N/A

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

None.

### Get in Touch

