### PR TITLE
Feat/install remote agents

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,8 @@
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"NODE_ENV": "development",
-				"VSCODE_DEBUG_MODE": "true"
+				"VSCODE_DEBUG_MODE": "true",
+				"COSTRICT_AGENT_CHECK_INTERVAL_MINUTES": "5"
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"presentation": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,8 +16,7 @@
 			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"NODE_ENV": "development",
-				"VSCODE_DEBUG_MODE": "true",
-				"COSTRICT_AGENT_CHECK_INTERVAL_MINUTES": "5"
+				"VSCODE_DEBUG_MODE": "true"
 			},
 			"resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
 			"presentation": {

--- a/packages/types/src/vscode.ts
+++ b/packages/types/src/vscode.ts
@@ -69,6 +69,8 @@ export const commandIds = [
 	"addFileToContext",
 	"toggleAutoApprove",
 	"generateCommitMessage",
+	"installAgentPackage",
+	"uninstallAgentPackage",
 ] as const
 
 export const costrictCommandIds = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,6 +1125,9 @@ importers:
       '@roo-code/config-typescript':
         specifier: workspace:^
         version: link:../packages/config-typescript
+      '@types/adm-zip':
+        specifier: ^0.5.8
+        version: 0.5.8
       '@types/async-retry':
         specifier: ^1.4.9
         version: 1.4.9
@@ -4323,6 +4326,9 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/adm-zip@0.5.8':
+    resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
 
   '@types/async-retry@1.4.9':
     resolution: {integrity: sha512-s1ciZQJzRh3708X/m3vPExr5KJlzlZJvXsKpbtE2luqNcbROr64qU+3KpJsYHqWMeaxI839OvXf9PrUSw1Xtyg==}
@@ -14017,6 +14023,8 @@ snapshots:
       '@types/readdir-glob': 1.1.5
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/adm-zip@0.5.8': {}
 
   '@types/async-retry@1.4.9':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -869,6 +869,9 @@ importers:
       '@vscode/codicons':
         specifier: ^0.0.45
         version: 0.0.45
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.17
       ai-sdk-provider-poe:
         specifier: 2.0.18
         version: 2.0.18(ai@6.0.154(zod@3.25.76))(zod@3.25.76)
@@ -1182,6 +1185,12 @@ importers:
       '@types/vscode':
         specifier: ^1.84.0
         version: 1.115.0
+      '@vitest/coverage-istanbul':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4)
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
       '@vscode/test-electron':
         specifier: ^2.5.2
         version: 2.5.2
@@ -1662,6 +1671,10 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
@@ -2000,24 +2013,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@basetenlabs/performance-client-linux-riscv64-gnu@0.0.10':
     resolution: {integrity: sha512-2KUvdK4wuoZdIqNnJhx7cu6ybXCwtiwGAtlrEvhai3FOkUQ3wE2Xa+TQ33mNGSyFbw6wAvLawYtKVFmmw27gJw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@basetenlabs/performance-client-linux-x64-gnu@0.0.10':
     resolution: {integrity: sha512-9jjQPjHLiVOGwUPlmhnBl7OmmO7hQ8WMt+v3mJuxkS5JTNDmVOngfmgGlbN9NjBhQMENjdcMUVOquVo7HeybGQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@basetenlabs/performance-client-linux-x64-musl@0.0.10':
     resolution: {integrity: sha512-bjYB8FKcPvEa251Ep2Gm3tvywADL9eavVjZsikdf0AvJ1K5pT+vLLvJBU9ihBsTPWnbF4pJgxVjwS6UjVObsQA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@basetenlabs/performance-client-win32-arm64-msvc@0.0.10':
     resolution: {integrity: sha512-Vxq5UXEmfh3C3hpwXdp3Daaf0dnLR9zFH2x8MJ1Hf/TcilmOP1clneewNpIv0e7MrnT56Z4pM6P3d8VFMZqBKg==}
@@ -2043,6 +2060,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
@@ -2468,89 +2489,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2719,24 +2756,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.3':
     resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.3':
     resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
@@ -2803,24 +2844,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/crc32-linux-arm64-musl@1.10.6':
     resolution: {integrity: sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/crc32-linux-x64-gnu@1.10.6':
     resolution: {integrity: sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/crc32-linux-x64-musl@1.10.6':
     resolution: {integrity: sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/crc32-wasm32-wasi@1.10.6':
     resolution: {integrity: sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==}
@@ -3634,36 +3679,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -3728,66 +3779,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -4104,24 +4168,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -4641,6 +4709,20 @@ packages:
     peerDependencies:
       vite: '>=6.4.2'
 
+  '@vitest/coverage-istanbul@3.2.4':
+    resolution: {integrity: sha512-IDlpuFJiWU9rhcKLkpzj8mFu/lpe64gVgnV15ZOrYx1iFzxxrxCzbExiUEKtwwXRvEiEMUS6iZeYgnMxgbqbxQ==}
+    peerDependencies:
+      vitest: 3.2.4
+
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -4818,6 +4900,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4982,6 +5068,9 @@ packages:
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -7386,8 +7475,16 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
@@ -7443,6 +7540,9 @@ packages:
   js-queue@2.0.2:
     resolution: {integrity: sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==}
     engines: {node: '>=1.0.0'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7635,24 +7735,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -7853,6 +7957,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -9867,6 +9974,10 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -10912,6 +11023,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
@@ -11669,6 +11785,8 @@ snapshots:
       '@basetenlabs/performance-client-win32-x64-msvc': 0.0.10
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -14357,6 +14475,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4)':
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      debug: 4.4.3(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.3.5
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.25.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.25.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -14601,6 +14754,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adm-zip@0.5.17: {}
+
   agent-base@7.1.4: {}
 
   agentkeepalive@4.6.0:
@@ -14835,6 +14990,12 @@ snapshots:
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -17389,11 +17550,29 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
 
   istanbul-reports@3.2.0:
     dependencies:
@@ -17461,6 +17640,8 @@ snapshots:
   js-queue@2.0.2:
     dependencies:
       easy-stack: 1.0.1
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -17868,6 +18049,12 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
@@ -20511,6 +20698,12 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 13.0.6
       minimatch: 3.1.5
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 13.0.6
+      minimatch: 10.2.5
 
   text-decoder@1.2.7:
     dependencies:

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -3,9 +3,19 @@ import * as vscode from "vscode"
 import { ClineProvider } from "../../core/webview/ClineProvider"
 
 import { getCommandsMap, getVisibleProviderOrLog } from "../registerCommands"
+import { RemoteAgentInstaller } from "../../core/costrict/remote-agent-installer"
 
 vi.mock("execa", () => ({
 	execa: vi.fn(),
+}))
+
+vi.mock("../../core/costrict/remote-agent-installer", () => ({
+	RemoteAgentInstaller: {
+		getInstance: vi.fn(() => ({
+			triggerManualInstall: vi.fn(),
+			getPackageName: vi.fn().mockReturnValue("Test Package"),
+		})),
+	},
 }))
 
 const mockTerminalManager = {
@@ -158,5 +168,48 @@ describe("registerCommands", () => {
 			type: "CostrictCliToast",
 			text: "File path inserted into CoStrict CLI",
 		})
+	})
+})
+
+
+describe("registerCommands installAgentPackage (US-002 FR-008)", () => {
+	let mockOutputChannel: vscode.OutputChannel
+
+	beforeEach(() => {
+		mockOutputChannel = {
+			appendLine: vi.fn(),
+			append: vi.fn(),
+			clear: vi.fn(),
+			hide: vi.fn(),
+			name: "mock",
+			replace: vi.fn(),
+			show: vi.fn(),
+			dispose: vi.fn(),
+		}
+		vi.clearAllMocks()
+		vi.mocked(vscode.window.showInformationMessage).mockClear()
+	})
+
+	// T017 [US2]: 手动命令触发 noUpdate 时仍调用 showInformationMessage
+	it("installAgentPackage should show information message on manual noUpdate", async () => {
+		const showInfoMock = vi.mocked(vscode.window.showInformationMessage)
+		showInfoMock.mockResolvedValue(undefined)
+
+		const mockInstaller = {
+			triggerManualInstall: vi.fn().mockResolvedValue({ state: "noUpdate" }),
+			getPackageName: vi.fn().mockReturnValue("Test Package"),
+		}
+		;(RemoteAgentInstaller.getInstance as Mock).mockReturnValue(mockInstaller)
+
+		const commands = getCommandsMap({
+			context: {} as vscode.ExtensionContext,
+			outputChannel: mockOutputChannel,
+			provider: {} as ClineProvider,
+		})
+
+		await commands.installAgentPackage()
+
+		expect(mockInstaller.triggerManualInstall).toHaveBeenCalled()
+		expect(showInfoMock).toHaveBeenCalled()
 	})
 })

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -20,6 +20,7 @@ import { EditorContext, EditorUtils } from "../integrations/editor/EditorUtils"
 import * as path from "path"
 import { handleGenerateCommitMessage } from "../core/costrict/commit"
 import { getTerminalManager } from "../core/costrict/cli-wrap"
+import { RemoteAgentInstaller } from "../core/costrict/remote-agent-installer"
 
 interface UriSource {
 	path: string
@@ -357,6 +358,35 @@ export const getCommandsMap = ({
 			const errorMessage = error instanceof Error ? error.message : String(error)
 			vscode.window.showErrorMessage(`Failed to generate commit message: ${errorMessage}`)
 			return undefined
+		}
+	},
+	// costrict: register remote agent installer commands
+	installAgentPackage: async () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		const result = await installer.triggerManualInstall()
+		const name = installer.getPackageName()
+		if (result.state === "installed") {
+			void vscode.window.showInformationMessage(
+				t("remoteAgentInstaller:info.installed", { name, version: result.version }),
+			)
+		} else if (result.state === "noUpdate") {
+			void vscode.window.showInformationMessage(t("remoteAgentInstaller:info.noUpdate", { name }))
+		} else if (result.state === "failed") {
+			void vscode.window.showErrorMessage(
+				t("remoteAgentInstaller:error.updateFailed", { name, reason: result.reason }),
+			)
+		}
+	},
+	uninstallAgentPackage: async () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		const result = await installer.triggerManualUninstall()
+		const name = installer.getPackageName()
+		if (result.success) {
+			void vscode.window.showInformationMessage(t("remoteAgentInstaller:info.uninstalled", { name }))
+		} else {
+			void vscode.window.showErrorMessage(
+				t("remoteAgentInstaller:error.uninstallFailed", { name, reason: result.reason }),
+			)
 		}
 	},
 })

--- a/src/core/config/CustomModesManager.ts
+++ b/src/core/config/CustomModesManager.ts
@@ -1000,7 +1000,8 @@ export class CustomModesManager {
 		}
 	}
 
-	private clearCache(): void {
+	public clearCache(): void {
+		//costrict: expose so ClineProvider can invalidate after remote agent reinstall
 		this.cachedModes = null
 		this.cachedAt = 0
 	}

--- a/src/core/config/__tests__/CustomModesManager.spec.ts
+++ b/src/core/config/__tests__/CustomModesManager.spec.ts
@@ -1757,4 +1757,58 @@ describe("CustomModesManager", () => {
 			expect(result.yaml).not.toContain("\\")
 		})
 	})
+
+	describe("clearCache", () => {
+		it("should force re-read from disk on next getCustomModes call after clearCache", async () => {
+			//costrict: verify TTL cache is invalidated so next getCustomModes re-reads from disk
+			const firstCallModes = [{ slug: "mode-v1", name: "Mode V1", roleDefinition: "Role V1", groups: ["read"] }]
+			const secondCallModes = [{ slug: "mode-v2", name: "Mode V2", roleDefinition: "Role V2", groups: ["read"] }]
+
+			let callCount = 0
+			;(fs.readFile as Mock).mockImplementation(async (filePath: string) => {
+				if (filePath === mockSettingsPath) {
+					callCount++
+					return callCount === 1
+						? yaml.stringify({ customModes: firstCallModes })
+						: yaml.stringify({ customModes: secondCallModes })
+				}
+				throw new Error("File not found")
+			})
+
+			const result1 = await manager.getCustomModes()
+			expect(result1[0].slug).toBe("mode-v1")
+
+			const result2 = await manager.getCustomModes()
+			expect(result2[0].slug).toBe("mode-v1")
+			expect(callCount).toBe(1)
+
+			manager.clearCache()
+			const result3 = await manager.getCustomModes()
+			expect(result3[0].slug).toBe("mode-v2")
+			expect(callCount).toBe(2)
+		})
+
+		it("should allow subsequent getCustomModes calls to re-populate the cache", async () => {
+			//costrict: verify cache can be re-populated after clearCache and hits cache on next call
+			const modes = [{ slug: "mode-a", name: "Mode A", roleDefinition: "Role A", groups: ["read"] }]
+			let readCount = 0
+			;(fs.readFile as Mock).mockImplementation(async (filePath: string) => {
+				if (filePath === mockSettingsPath) {
+					readCount++
+					return yaml.stringify({ customModes: modes })
+				}
+				throw new Error("File not found")
+			})
+
+			await manager.getCustomModes()
+			expect(readCount).toBe(1)
+
+			manager.clearCache()
+			await manager.getCustomModes()
+			expect(readCount).toBe(2)
+
+			await manager.getCustomModes()
+			expect(readCount).toBe(2)
+		})
+	})
 })

--- a/src/core/costrict/activate.ts
+++ b/src/core/costrict/activate.ts
@@ -45,6 +45,7 @@ import { t } from "../../i18n"
 import prettyBytes from "pretty-bytes"
 import { isCliPatform, isJetbrainsPlatform } from "../../utils/platform"
 import { updateDefaultDebug } from "../../utils/getDebugState"
+import { RemoteAgentInstaller } from "./remote-agent-installer"
 
 const HISTORY_WARN_SIZE = 1000 * 1000 * 1000 * 3
 
@@ -222,6 +223,17 @@ export async function activate(
 	setTimeout(() => {
 		loginTip()
 	}, 2000)
+
+	// costrict: start remote agent installer background check after CostrictAuthApi.setProvider()
+	// has been called (inside initialize()), so that getApiConfiguration() can read the user's
+	// costrictBaseUrl from the provider state instead of falling back to an empty string.
+	try {
+		RemoteAgentInstaller.getInstance(context).scheduleBackgroundCheck()
+	} catch (error: any) {
+		outputChannel.appendLine(
+			`[RemoteAgentInstaller] Failed to start background check: ${error instanceof Error ? error.message : String(error)}`,
+		)
+	}
 }
 
 /**
@@ -234,4 +246,8 @@ export async function deactivate() {
 	void disconnectIPC()
 	void stopIPCServer()
 	loggerDeactivate()
+
+	// costrict: dispose remote agent installer (use disposeInstance to avoid creating a new
+	// instance just to immediately dispose it when the singleton was never initialized)
+	RemoteAgentInstaller.disposeInstance()
 }

--- a/src/core/costrict/remote-agent-installer/AgentDownloader.ts
+++ b/src/core/costrict/remote-agent-installer/AgentDownloader.ts
@@ -1,0 +1,230 @@
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import * as http from "http"
+import * as https from "https"
+import * as os from "os"
+import * as path from "path"
+import * as crypto from "crypto"
+import { URL } from "url"
+import { createLogger } from "../../../utils/logger"
+import { Package } from "../../../shared/package"
+import { FatalInstallerError } from "./types"
+import type { ResourcePackageVersion } from "./types"
+
+const logger = createLogger(Package.outputChannel)
+const LOG_PREFIX = "[remote-agent-installer:download]"
+
+const DOWNLOAD_TIMEOUT_MS = 120_000
+const MAX_REDIRECTS = 5
+
+export interface DownloadProgress {
+	downloaded: number
+	total: number
+	progress: number
+}
+
+export class AgentDownloader {
+	private tmpDir: string
+
+	constructor(tmpDir?: string) {
+		// Use the OS-provided temp directory by default (auto-cleaned on reboot,
+		// does not pollute the user's home directory with large zip files).
+		this.tmpDir = tmpDir || path.join(os.tmpdir(), "costrict-remote-agent")
+	}
+
+	getTmpDir(): string {
+		return this.tmpDir
+	}
+
+	async download(
+		versionInfo: ResourcePackageVersion,
+		onProgress?: (progress: DownloadProgress) => void,
+	): Promise<string> {
+		const version = versionInfo.version
+		const zipFileName = `remote-agent-package-${version}.zip`
+		const targetPath = path.join(this.tmpDir, zipFileName)
+		const downloadingPath = `${targetPath}.downloading`
+
+		// Clean up residual files before downloading; see cleanupResidualFiles() JSDoc for safety rationale.
+		await this.cleanupResidualFiles(version)
+
+		// No internal retry — all retry logic is handled by the outer runInstallWithRetries (FR-014).
+		try {
+			await fs.mkdir(this.tmpDir, { recursive: true })
+			await this.downloadToFile(versionInfo.downloadUrl!, downloadingPath, onProgress)
+			await fs.rename(downloadingPath, targetPath)
+
+			if (versionInfo.checksum && versionInfo.checksumAlgo) {
+				await this.verifyChecksum(targetPath, versionInfo.checksum, versionInfo.checksumAlgo)
+			}
+
+			logger.info(`${LOG_PREFIX} Download completed: ${zipFileName}`)
+			return targetPath
+		} catch (error: any) {
+			logger.warn(`${LOG_PREFIX} Download failed: ${error.message}`)
+			try {
+				await fs.unlink(downloadingPath)
+			} catch {
+				// ignore cleanup error
+			}
+			try {
+				await fs.unlink(targetPath)
+			} catch {
+				// ignore cleanup error
+			}
+			throw error
+		}
+	}
+
+	/**
+	 * Removes ALL `remote-agent-package-*` files and directories from the tmp directory.
+	 * This includes the current version's zip if it happens to exist.
+	 *
+	 * This is safe to call at the start of `download()` because the outer retry logic in
+	 * `RemoteAgentInstaller.runInstallWithRetries` only skips `download()` when a zip
+	 * returned by a *previous* `download()` call still exists on disk. Since `download()`
+	 * only returns after successfully writing the file, `cleanupResidualFiles` can never
+	 * delete a zip that the outer retry logic is relying on.
+	 */
+	async cleanupResidualFiles(_currentVersion?: string): Promise<void> {
+		try {
+			const entries = await fs.readdir(this.tmpDir)
+			const prefix = "remote-agent-package-"
+			for (const entry of entries) {
+				if (!entry.startsWith(prefix)) continue
+				try {
+					const entryPath = path.join(this.tmpDir, entry)
+					const stat = await fs.stat(entryPath).catch(() => null)
+					if (!stat) continue
+					if (stat.isDirectory()) {
+						await fs.rm(entryPath, { recursive: true, force: true })
+					} else {
+						await fs.unlink(entryPath)
+					}
+					logger.info(`${LOG_PREFIX} Cleaned up residual file: ${entry}`)
+				} catch {
+					// ignore individual cleanup errors
+				}
+			}
+		} catch {
+			// ignore if tmp dir does not exist
+		}
+	}
+
+	private downloadToFile(
+		url: string,
+		filePath: string,
+		onProgress?: (progress: DownloadProgress) => void,
+		redirectCount = 0,
+	): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const parsed = new URL(url)
+			const client = parsed.protocol === "https:" ? https : http
+
+			let fileStream: fsSync.WriteStream | null = null
+
+			const cleanupStream = () => {
+				if (fileStream) {
+					try {
+						fileStream.close()
+					} catch {
+						// ignore
+					}
+					fileStream = null
+				}
+			}
+
+			const request = client.get(url, { timeout: DOWNLOAD_TIMEOUT_MS }, (response) => {
+				if (
+					response.statusCode &&
+					response.statusCode >= 300 &&
+					response.statusCode < 400 &&
+					response.headers.location
+				) {
+					if (redirectCount >= MAX_REDIRECTS) {
+						// Consume the response to release the socket
+						response.resume()
+						reject(new Error(`Too many redirects (max ${MAX_REDIRECTS})`))
+						return
+					}
+					// Consume the redirect response body to release the socket before following
+					response.resume()
+					this.downloadToFile(response.headers.location, filePath, onProgress, redirectCount + 1)
+						.then(resolve)
+						.catch(reject)
+					return
+				}
+
+				if (response.statusCode !== 200) {
+					// Consume the response to release the socket
+					response.resume()
+					reject(new Error(`HTTP ${response.statusCode}`))
+					return
+				}
+
+				const total = parseInt(response.headers["content-length"] || "0", 10)
+				let downloaded = 0
+
+				fileStream = fsSync.createWriteStream(filePath)
+				response.pipe(fileStream)
+
+				response.on("data", (chunk: Buffer) => {
+					downloaded += chunk.length
+					if (onProgress && total > 0) {
+						onProgress({
+							downloaded,
+							total,
+							progress: Math.round((downloaded / total) * 100),
+						})
+					}
+				})
+
+				fileStream.on("finish", () => {
+					fileStream!.close()
+					resolve()
+				})
+
+				fileStream.on("error", (err) => {
+					cleanupStream()
+					reject(err)
+				})
+			})
+
+			request.on("error", (err) => {
+				cleanupStream()
+				reject(err)
+			})
+
+			request.on("timeout", () => {
+				request.destroy()
+				cleanupStream()
+				reject(new Error("Request timeout"))
+			})
+		})
+	}
+
+	private async verifyChecksum(filePath: string, expected: string, algo: string): Promise<void> {
+		const hash = crypto.createHash(algo)
+		const stream = fsSync.createReadStream(filePath)
+		return new Promise((resolve, reject) => {
+			stream.on("data", (chunk) => hash.update(chunk))
+			stream.on("end", () => {
+				const actual = hash.digest("hex")
+				if (actual !== expected) {
+					// Checksum mismatch is a fatal error (content corruption / MITM attack).
+					// Throw FatalInstallerError so the outer retry logic stops immediately
+					// instead of retrying 3 times with the same corrupted file.
+					reject(
+						new FatalInstallerError(
+							"checksumMismatch",
+							`Checksum mismatch: expected ${expected}, got ${actual}`,
+						),
+					)
+				} else {
+					resolve()
+				}
+			})
+			stream.on("error", reject)
+		})
+	}
+}

--- a/src/core/costrict/remote-agent-installer/AgentInstaller.ts
+++ b/src/core/costrict/remote-agent-installer/AgentInstaller.ts
@@ -1,0 +1,784 @@
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import * as os from "os"
+import * as path from "path"
+import * as yaml from "yaml"
+import AdmZip from "adm-zip"
+import { createLogger } from "../../../utils/logger"
+import { Package } from "../../../shared/package"
+import { safeWriteJson } from "../../../utils/safeWriteJson"
+import { getGlobalRooDirectory } from "../../../services/roo-config/index"
+import { delay, redactUrl } from "./utils"
+import type { ResourcePackageVersion, LocalInstallRecord, ZipManifest, InstalledManifest } from "./types"
+import { FatalInstallerError } from "./types"
+
+const logger = createLogger(Package.outputChannel)
+const LOG_PREFIX = "[remote-agent-installer:install]"
+
+const WINDOWS_RESERVED_NAMES = new Set([
+	"CON",
+	"PRN",
+	"AUX",
+	"NUL",
+	"COM1",
+	"COM2",
+	"COM3",
+	"COM4",
+	"COM5",
+	"COM6",
+	"COM7",
+	"COM8",
+	"COM9",
+	"LPT1",
+	"LPT2",
+	"LPT3",
+	"LPT4",
+	"LPT5",
+	"LPT6",
+	"LPT7",
+	"LPT8",
+	"LPT9",
+])
+
+export async function atomicCopyFile(src: string, dest: string, maxRetries = 5): Promise<void> {
+	const tmpDest = `${dest}.tmp-${Date.now()}`
+	await fs.copyFile(src, tmpDest)
+	for (let i = 0; i < maxRetries; i++) {
+		try {
+			await fs.rename(tmpDest, dest)
+			return
+		} catch (error: any) {
+			if ((error.code === "EPERM" || error.code === "EBUSY") && i < maxRetries - 1) {
+				await delay(100 * Math.pow(2, i))
+				continue
+			}
+			await fs.unlink(tmpDest).catch(() => {})
+			throw error
+		}
+	}
+}
+
+export async function atomicReplaceDirectory(src: string, dest: string): Promise<void> {
+	const backup = `${dest}.backup-${Date.now()}`
+	let hasBackup = false
+	try {
+		await fs.rename(dest, backup)
+		hasBackup = true
+	} catch (error: any) {
+		if (error.code !== "ENOENT") {
+			if (process.platform === "win32" && (error.code === "EPERM" || error.code === "EBUSY")) {
+				await fs.rm(dest, { recursive: true, force: true, maxRetries: 3 })
+			} else {
+				throw error
+			}
+		}
+	}
+	// On Windows, fs.rename() to a path that still exists (or was recently deleted)
+	// can fail with EPERM due to filesystem delays. Fall back to cp+rm in that case.
+	try {
+		await fs.rename(src, dest)
+	} catch (renameError: any) {
+		if (process.platform === "win32" && (renameError.code === "EPERM" || renameError.code === "EBUSY")) {
+			// Windows fallback: cp+rm. If cp fails, restore backup so dest is not lost.
+			try {
+				await fs.cp(src, dest, { recursive: true })
+				await fs.rm(src, { recursive: true, force: true })
+			} catch (cpError: any) {
+				if (hasBackup) {
+					await fs.rename(backup, dest).catch(() => {})
+				}
+				throw cpError
+			}
+		} else {
+			// Restore backup to dest before re-throwing, so the original dest is not lost.
+			if (hasBackup) {
+				await fs.rename(backup, dest).catch(() => {})
+			}
+			throw renameError
+		}
+	}
+	if (hasBackup) {
+		// Fire-and-forget cleanup of the backup directory. This is safe because:
+		// 1. The backup path includes a unique timestamp (Date.now()), so it cannot
+		//    conflict with any other path used by concurrent or subsequent operations.
+		// 2. The backup is only a safety net for rollback; once the rename/copy to dest
+		//    has succeeded, the backup is no longer needed and its cleanup is non-critical.
+		// 3. Awaiting this would delay the caller unnecessarily for a best-effort cleanup.
+		fs.rm(backup, { recursive: true, force: true }).catch(() => {})
+	}
+}
+
+/**
+ * Atomically write a YAML file: write to a temp file first, then rename.
+ */
+async function atomicWriteYaml(filePath: string, data: unknown): Promise<void> {
+	const tmpPath = `${filePath}.tmp-${Date.now()}`
+	await fs.mkdir(path.dirname(filePath), { recursive: true })
+	await fs.writeFile(tmpPath, yaml.stringify(data), "utf-8")
+	for (let i = 0; i < 5; i++) {
+		try {
+			await fs.rename(tmpPath, filePath)
+			return
+		} catch (error: any) {
+			if ((error.code === "EPERM" || error.code === "EBUSY") && i < 4) {
+				await delay(100 * Math.pow(2, i))
+				continue
+			}
+			await fs.unlink(tmpPath).catch(() => {})
+			throw error
+		}
+	}
+}
+
+function isWindowsReservedName(name: string): boolean {
+	const base = name.split(".")[0].toUpperCase()
+	return WINDOWS_RESERVED_NAMES.has(base)
+}
+
+function isPathInside(target: string, root: string): boolean {
+	const resolvedTarget = path.resolve(target)
+	const resolvedRoot = path.resolve(root)
+	const relative = path.relative(resolvedRoot, resolvedTarget)
+	return !relative.startsWith("..") && !path.isAbsolute(relative)
+}
+
+export class AgentInstaller {
+	private tmpDir: string
+	private rooDir: string
+	/**
+	 * settingsDir is the VSCode extension's private settings directory
+	 * (obtained via `getSettingsDirectoryPath(context.globalStorageUri.fsPath)`).
+	 *
+	 * This is the correct location for `custom_modes.yaml` and `mcp_settings.json`
+	 * because `CustomModesManager` and `McpHub` both read/write these files from
+	 * `settingsDir`, NOT from `~/.roo/`. Writing to `settingsDir` ensures that
+	 * the file-watchers in `CustomModesManager.watchCustomModesFiles()` and
+	 * `McpHub.watchMcpSettingsFile()` can detect the changes and hot-reload.
+	 *
+	 * When `settingsDir` is undefined (e.g. in unit tests that construct
+	 * `AgentInstaller` directly without a VSCode context), the code falls back
+	 * to `rooDir` so that tests remain self-contained without needing a real
+	 * VSCode extension context.
+	 */
+	private settingsDir?: string
+
+	constructor(tmpDir?: string, rooDir?: string, settingsDir?: string) {
+		// Use the OS-provided temp directory by default (auto-cleaned on reboot,
+		// does not pollute the user's home directory with large extracted files).
+		this.tmpDir = tmpDir || path.join(os.tmpdir(), "costrict-remote-agent")
+		this.rooDir = rooDir || getGlobalRooDirectory()
+		this.settingsDir = settingsDir
+	}
+
+	getTmpDir(): string {
+		return this.tmpDir
+	}
+
+	async install(
+		zipPath: string,
+		versionInfo: ResourcePackageVersion,
+		record: LocalInstallRecord,
+	): Promise<InstalledManifest> {
+		const extractDir = path.join(this.tmpDir, `remote-agent-package-${versionInfo.version}`)
+		try {
+			await fs.mkdir(extractDir, { recursive: true })
+			this.extractZip(zipPath, extractDir)
+			const manifest = this.readZipManifest(extractDir, versionInfo.version)
+
+			// uninstall failure must not block install; log and continue.
+			try {
+				await this.uninstall(record)
+			} catch (uninstallError: any) {
+				logger.warn(
+					`${LOG_PREFIX} Pre-install uninstall failed (non-blocking): ${uninstallError?.message ?? uninstallError}`,
+				)
+			}
+
+			const installedManifest: InstalledManifest = {
+				agents: [],
+				commands: [],
+				skills: [],
+				rules: [],
+				mcp: [],
+			}
+
+			const declaredModules = new Set(manifest.modules || [])
+			const modulesToInstall: Array<keyof InstalledManifest> = ["agents", "commands", "skills", "rules", "mcp"]
+
+			for (const moduleType of modulesToInstall) {
+				const moduleDir = path.join(extractDir, moduleType)
+				const exists = await fs
+					.stat(moduleDir)
+					.then((s) => s.isDirectory())
+					.catch(() => false)
+				if (!exists) {
+					if (declaredModules.has(moduleType)) {
+						logger.warn(`${LOG_PREFIX} manifest declares "${moduleType}" but missing in zip, skipping`)
+					}
+					continue
+				}
+				try {
+					await this.installModule(moduleType, moduleDir, installedManifest, versionInfo.version)
+				} catch (error: any) {
+					logger.error(`${LOG_PREFIX} Failed to install module ${moduleType}: ${error.message}`)
+					throw error
+				}
+			}
+			logger.info(
+				`${LOG_PREFIX} Installation completed, modules: ${modulesToInstall
+					.filter((m) => installedManifest[m].length > 0)
+					.join(", ")}`,
+			)
+			const warnings = await this.verifyInstalled(installedManifest)
+			if (warnings.length > 0) {
+				logger.warn(
+					`${LOG_PREFIX} Installation verification warnings:\n${warnings.map((w) => `  - ${w}`).join("\n")}`,
+				)
+			} else {
+				logger.info(`${LOG_PREFIX} Installation verified successfully`)
+			}
+			await this.cleanup(undefined, extractDir)
+			return installedManifest
+		} catch (error) {
+			// Only clean up the extract dir; zipPath is preserved for outer retry reuse.
+			// runInstallWithRetries cleans zipPath on final failure.
+			await this.cleanup(undefined, extractDir)
+			throw error
+		}
+	}
+
+	async uninstall(record: LocalInstallRecord): Promise<void> {
+		if (!record.manifest) {
+			return
+		}
+		const { agents, commands, skills, rules, mcp } = record.manifest
+
+		if (agents.length > 0) {
+			try {
+				await this.uninstallAgents(agents)
+			} catch (error: any) {
+				logger.warn(`${LOG_PREFIX} Failed to uninstall agents: ${error.message}`)
+			}
+		}
+
+		for (const cmd of commands) {
+			try {
+				await this.uninstallCommand(cmd)
+			} catch (error: any) {
+				logger.warn(`${LOG_PREFIX} Failed to uninstall command ${cmd}: ${error.message}`)
+			}
+		}
+
+		for (const skill of skills) {
+			try {
+				await this.uninstallSkill(skill)
+			} catch (error: any) {
+				logger.warn(`${LOG_PREFIX} Failed to uninstall skill ${skill}: ${error.message}`)
+			}
+		}
+
+		for (const rule of rules) {
+			try {
+				await this.uninstallRule(rule)
+			} catch (error: any) {
+				logger.warn(`${LOG_PREFIX} Failed to uninstall rule ${rule}: ${error.message}`)
+			}
+		}
+		if (mcp.length > 0) {
+			try {
+				await this.uninstallMcp(mcp)
+			} catch (error: any) {
+				logger.warn(`${LOG_PREFIX} Failed to uninstall mcp: ${error.message}`)
+			}
+		}
+		// verifyUninstalled is a non-critical diagnostic step.
+		// Wrap it in try-catch so unexpected errors don't propagate and fail the uninstall.
+		try {
+			const warnings = await this.verifyUninstalled(record.manifest)
+			if (warnings.length > 0) {
+				logger.warn(
+					`${LOG_PREFIX} Uninstallation verification warnings:\n${warnings.map((w) => `  - ${w}`).join("\n")}`,
+				)
+			} else {
+				logger.info(`${LOG_PREFIX} Uninstallation verified successfully`)
+			}
+		} catch (error: any) {
+			logger.warn(`${LOG_PREFIX} Uninstallation verification failed unexpectedly: ${error.message}`)
+		}
+	}
+
+	async cleanup(zipPath?: string, extractDir?: string): Promise<void> {
+		if (extractDir) {
+			try {
+				await fs.rm(extractDir, { recursive: true, force: true })
+			} catch {
+				// ignore
+			}
+		}
+		if (zipPath) {
+			try {
+				await fs.unlink(zipPath)
+			} catch {
+				// ignore
+			}
+		}
+	}
+
+	private extractZip(zipPath: string, extractDir: string): void {
+		const zip = new AdmZip(zipPath)
+		const entries = zip.getEntries()
+		for (const entry of entries) {
+			// Normalize separators to forward slashes before checking for traversal.
+			// This catches both Unix-style "../evil" and Windows-style "..\evil" entries.
+			const normalized = entry.entryName.replace(/\\/g, "/")
+			// Use path-segment matching instead of includes("..") to avoid false positives
+			// on legitimate filenames like "..hidden" or "file..name".
+			// A traversal segment is exactly ".." (not "..hidden" or "file..name").
+			const segments = normalized.split("/")
+			if (segments.some((seg) => seg === "..") || normalized.startsWith("/")) {
+				throw new FatalInstallerError("pathTraversal", `Zip entry contains path traversal: ${entry.entryName}`)
+			}
+		}
+		zip.extractAllTo(extractDir, true)
+	}
+
+	private readZipManifest(extractDir: string, expectedVersion: string): ZipManifest {
+		const manifestPath = path.join(extractDir, "manifest.json")
+		if (!fsSync.existsSync(manifestPath)) {
+			throw new FatalInstallerError("manifestMissing", "manifest.json is missing in the zip package")
+		}
+		let manifest: ZipManifest
+		try {
+			manifest = JSON.parse(fsSync.readFileSync(manifestPath, "utf-8"))
+		} catch {
+			throw new FatalInstallerError("manifestParseError", "manifest.json is not valid JSON")
+		}
+		if (!manifest.version) {
+			throw new FatalInstallerError("manifestParseError", "manifest.json missing required field: version")
+		}
+		if (manifest.version !== expectedVersion) {
+			throw new FatalInstallerError(
+				"manifestVersionMismatch",
+				`manifest version mismatch: expected ${expectedVersion}, got ${manifest.version}`,
+			)
+		}
+		return manifest
+	}
+
+	private async installModule(
+		moduleType: keyof InstalledManifest,
+		moduleDir: string,
+		manifest: InstalledManifest,
+		version: string,
+	): Promise<void> {
+		switch (moduleType) {
+			case "agents":
+				manifest.agents = await this.installAgents(moduleDir, version)
+				break
+			case "commands":
+				manifest.commands = await this.installCommands(moduleDir, version)
+				break
+			case "skills":
+				manifest.skills = await this.installSkills(moduleDir, version)
+				break
+			case "rules":
+				manifest.rules = await this.installRules(moduleDir)
+				break
+			case "mcp":
+				manifest.mcp = await this.installMcp(moduleDir)
+				break
+		}
+	}
+
+	private async installAgents(agentsDir: string, version: string): Promise<string[]> {
+		const customModesPath = path.join(this.settingsDir || this.rooDir, "custom_modes.yaml")
+		const files = await fs.readdir(agentsDir)
+		const yamlFiles = files.filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+		const slugs: string[] = []
+
+		let customModes: any = { customModes: [] }
+		try {
+			const content = await fs.readFile(customModesPath, "utf-8")
+			customModes = yaml.parse(content) || { customModes: [] }
+		} catch (error: any) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+				// Local config file is corrupted — log a warning and reset to empty rather than
+				// treating it as a fatal error. The corrupted file will be overwritten with valid
+				// content at the end of installAgents(), effectively auto-repairing it.
+				logger.warn(
+					`${LOG_PREFIX} Failed to parse local custom_modes.yaml, resetting to empty: ${error.message}`,
+				)
+			}
+			customModes = { customModes: [] }
+		}
+
+		if (!Array.isArray(customModes.customModes)) {
+			customModes.customModes = []
+		}
+
+		for (const file of yamlFiles) {
+			const filePath = path.join(agentsDir, file)
+			// Path safety for zip contents is enforced by extractZip(); no additional check needed here.
+			try {
+				const rawContent = await fs.readFile(filePath, "utf-8")
+				const content = rawContent.replace(/\$\{version\}/g, version)
+				const modeConfig = yaml.parse(content)
+				if (!modeConfig || !modeConfig.slug) {
+					logger.warn(`${LOG_PREFIX} YAML file ${file} missing slug, skipping`)
+					continue
+				}
+				const idx = customModes.customModes.findIndex((m: any) => m.slug === modeConfig.slug)
+				if (idx >= 0) {
+					customModes.customModes[idx] = modeConfig
+				} else {
+					customModes.customModes.push(modeConfig)
+				}
+				slugs.push(modeConfig.slug)
+			} catch (error: any) {
+				throw new FatalInstallerError("yamlParseError", `Failed to parse agent YAML ${file}: ${error.message}`)
+			}
+		}
+
+		await atomicWriteYaml(customModesPath, customModes)
+		return slugs
+	}
+
+	private async installCommands(commandsDir: string, version: string): Promise<string[]> {
+		const targetDir = path.join(this.rooDir, "commands")
+		await fs.mkdir(targetDir, { recursive: true })
+		const files = await fs.readdir(commandsDir)
+		const mdFiles = files.filter((f) => f.endsWith(".md"))
+		const installed: string[] = []
+
+		for (const file of mdFiles) {
+			const src = path.join(commandsDir, file)
+			const dest = path.join(targetDir, file)
+			this.assertPathSafe(dest, targetDir)
+			if (process.platform === "win32" && isWindowsReservedName(file)) {
+				throw new FatalInstallerError("reservedDeviceName", `Reserved device name: ${file}`)
+			}
+			// Replace ${version} placeholder before copying so the final write is atomic.
+			// Reading from src (in the temp extract dir) avoids a non-atomic read-modify-write
+			// on the destination file.
+			const content = await fs.readFile(src, "utf-8")
+			const replaced = content.replace(/\$\{version\}/g, version)
+			if (replaced !== content) {
+				// Write the replaced content to a temp file, then atomically copy to dest.
+				const tmpSrc = `${src}.tmp-${Date.now()}`
+				await fs.writeFile(tmpSrc, replaced, "utf-8")
+				try {
+					await atomicCopyFile(tmpSrc, dest)
+				} finally {
+					await fs.unlink(tmpSrc).catch(() => {})
+				}
+			} else {
+				await atomicCopyFile(src, dest)
+			}
+			installed.push(file)
+		}
+		return installed
+	}
+
+	private async installSkills(skillsDir: string, version: string): Promise<string[]> {
+		const targetDir = path.join(this.rooDir, "skills")
+		await fs.mkdir(targetDir, { recursive: true })
+		const entries = await fs.readdir(skillsDir, { withFileTypes: true })
+		const dirs = entries.filter((e) => e.isDirectory())
+		const installed: string[] = []
+
+		for (const dir of dirs) {
+			const skillName = dir.name
+			const src = path.join(skillsDir, skillName)
+			const dest = path.join(targetDir, skillName)
+			this.assertPathSafe(dest, targetDir)
+			if (process.platform === "win32" && isWindowsReservedName(skillName)) {
+				throw new FatalInstallerError("reservedDeviceName", `Reserved device name: ${skillName}`)
+			}
+
+			const tmpDest = `${dest}.tmp-${Date.now()}`
+			await fs.cp(src, tmpDest, { recursive: true })
+			await this.replaceSkillPathPlaceholders(
+				tmpDest,
+				path.join(targetDir, skillName).replace(/\\/g, "/"),
+				version,
+			)
+			await atomicReplaceDirectory(tmpDest, dest)
+			installed.push(skillName)
+		}
+		return installed
+	}
+
+	private async replaceSkillPathPlaceholders(dir: string, skillPath: string, version: string): Promise<void> {
+		const entries = await fs.readdir(dir, { withFileTypes: true })
+		for (const entry of entries) {
+			const fullPath = path.join(dir, entry.name)
+			if (entry.isDirectory()) {
+				await this.replaceSkillPathPlaceholders(fullPath, skillPath, version)
+			} else if (entry.name.endsWith(".md")) {
+				const content = await fs.readFile(fullPath, "utf-8")
+				const replaced = content.replace(/\$\{skill_path\}/g, skillPath).replace(/\$\{version\}/g, version)
+				if (replaced !== content) {
+					await fs.writeFile(fullPath, replaced, "utf-8")
+				}
+			}
+		}
+	}
+
+	private async installRules(rulesDir: string): Promise<string[]> {
+		// Rules are installed directly under rooDir (e.g., ~/.roo/{rules_dirname}).
+		// Each entry in the zip's rules/ directory maps to ~/.roo/{entry_name}.
+		const targetDir = this.rooDir
+		const entries = await fs.readdir(rulesDir, { withFileTypes: true })
+		const installed: string[] = []
+
+		for (const entry of entries) {
+			const name = entry.name
+			const src = path.join(rulesDir, name)
+			const dest = path.join(targetDir, name)
+			this.assertPathSafe(dest, targetDir)
+			if (process.platform === "win32" && isWindowsReservedName(name)) {
+				throw new FatalInstallerError("reservedDeviceName", `Reserved device name: ${name}`)
+			}
+
+			if (entry.isDirectory()) {
+				const tmpDest = `${dest}.tmp-${Date.now()}`
+				await fs.cp(src, tmpDest, { recursive: true })
+				await atomicReplaceDirectory(tmpDest, dest)
+			} else {
+				await atomicCopyFile(src, dest)
+			}
+			installed.push(name)
+		}
+		return installed
+	}
+
+	private async installMcp(mcpDir: string): Promise<string[]> {
+		const mcpSettingsPath = path.join(this.settingsDir || this.rooDir, "mcp_settings.json")
+		const files = await fs.readdir(mcpDir)
+		const jsonFiles = files.filter((f) => f.endsWith(".json"))
+		const serverNames: string[] = []
+
+		let settings: any = { mcpServers: {} }
+		try {
+			const content = await fs.readFile(mcpSettingsPath, "utf-8")
+			settings = JSON.parse(content)
+		} catch (error: any) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+				// Local config file is corrupted — log a warning and reset to empty rather than
+				// treating it as a fatal error. The corrupted file will be overwritten with valid
+				// content at the end of installMcp(), effectively auto-repairing it.
+				logger.warn(
+					`${LOG_PREFIX} Failed to parse local mcp_settings.json, resetting to empty: ${error.message}`,
+				)
+			}
+			settings = { mcpServers: {} }
+		}
+
+		if (!settings.mcpServers || typeof settings.mcpServers !== "object") {
+			settings.mcpServers = {}
+		}
+
+		for (const file of jsonFiles) {
+			const filePath = path.join(mcpDir, file)
+			// Path safety for zip contents is enforced by extractZip(); no additional check needed here.
+			try {
+				const content = await fs.readFile(filePath, "utf-8")
+				const serverConfig = JSON.parse(content)
+				if (!serverConfig || typeof serverConfig !== "object") {
+					continue
+				}
+				const name = serverConfig.name || path.basename(file, ".json")
+				// Exclude the `name` field from the stored config — it's used as the key,
+				// not as part of the server configuration value in mcp_settings.json.
+				const { name: _name, ...serverConfigWithoutName } = serverConfig
+				settings.mcpServers[name] = serverConfigWithoutName
+				serverNames.push(name)
+			} catch (error: any) {
+				throw new FatalInstallerError("jsonParseError", `Failed to parse MCP JSON ${file}: ${error.message}`)
+			}
+		}
+
+		await safeWriteJson(mcpSettingsPath, settings)
+		return serverNames
+	}
+
+	private async uninstallAgents(slugs: string[]): Promise<void> {
+		const customModesPath = path.join(this.settingsDir || this.rooDir, "custom_modes.yaml")
+		if (!fsSync.existsSync(customModesPath)) {
+			return
+		}
+		const content = fsSync.readFileSync(customModesPath, "utf-8")
+		const data = yaml.parse(content) || { customModes: [] }
+		if (Array.isArray(data.customModes)) {
+			data.customModes = data.customModes.filter((m: any) => !slugs.includes(m?.slug))
+		}
+		await atomicWriteYaml(customModesPath, data)
+	}
+
+	private async uninstallCommand(fileName: string): Promise<void> {
+		const filePath = path.join(this.rooDir, "commands", fileName)
+		await fs.unlink(filePath).catch(() => {})
+	}
+
+	private async uninstallSkill(skillName: string): Promise<void> {
+		const dirPath = path.join(this.rooDir, "skills", skillName)
+		await fs.rm(dirPath, { recursive: true, force: true }).catch(() => {})
+	}
+
+	private async uninstallRule(ruleName: string): Promise<void> {
+		const rulePath = path.join(this.rooDir, ruleName)
+		const stat = await fs.stat(rulePath).catch(() => null)
+		if (!stat) {
+			return
+		}
+		if (stat.isDirectory()) {
+			await fs.rm(rulePath, { recursive: true, force: true }).catch(() => {})
+		} else {
+			await fs.unlink(rulePath).catch(() => {})
+		}
+	}
+
+	private async uninstallMcp(serverNames: string[]): Promise<void> {
+		const mcpSettingsPath = path.join(this.settingsDir || this.rooDir, "mcp_settings.json")
+		if (!fsSync.existsSync(mcpSettingsPath)) {
+			return
+		}
+		const content = fsSync.readFileSync(mcpSettingsPath, "utf-8")
+		let data: any
+		try {
+			data = JSON.parse(content)
+		} catch (error: any) {
+			// mcp_settings.json is corrupted — log a precise warning and skip the write.
+			// Without this try/catch the SyntaxError would propagate to uninstall()'s outer
+			// catch block, which logs a generic "Failed to uninstall mcp" message that
+			// obscures the real cause (invalid JSON) and makes debugging harder.
+			logger.warn(
+				`${LOG_PREFIX} mcp_settings.json contains invalid JSON, skipping MCP uninstall: ${error.message}`,
+			)
+			return
+		}
+		if (data.mcpServers && typeof data.mcpServers === "object") {
+			for (const name of serverNames) {
+				delete data.mcpServers[name]
+			}
+			await safeWriteJson(mcpSettingsPath, data)
+		}
+	}
+
+	private async verifyInstalled(manifest: InstalledManifest): Promise<string[]> {
+		const warnings: string[] = []
+
+		if (manifest.agents.length > 0) {
+			const customModesPath = path.join(this.settingsDir || this.rooDir, "custom_modes.yaml")
+			if (!fsSync.existsSync(customModesPath)) {
+				warnings.push(`custom_modes.yaml missing`)
+			} else {
+				try {
+					const data = yaml.parse(fsSync.readFileSync(customModesPath, "utf-8"))
+					const slugs = new Set((data?.customModes || []).map((m: any) => m?.slug).filter(Boolean))
+					for (const slug of manifest.agents) {
+						if (!slugs.has(slug)) warnings.push(`agent "${slug}" not found in custom_modes.yaml`)
+					}
+				} catch (e: any) {
+					warnings.push(`failed to read custom_modes.yaml: ${e.message}`)
+				}
+			}
+		}
+
+		if (manifest.mcp.length > 0) {
+			const mcpSettingsPath = path.join(this.settingsDir || this.rooDir, "mcp_settings.json")
+			if (!fsSync.existsSync(mcpSettingsPath)) {
+				warnings.push(`mcp_settings.json missing`)
+			} else {
+				try {
+					const data = JSON.parse(fsSync.readFileSync(mcpSettingsPath, "utf-8"))
+					for (const name of manifest.mcp) {
+						if (!data?.mcpServers?.[name]) warnings.push(`mcp server "${name}" not found`)
+					}
+				} catch (e: any) {
+					warnings.push(`failed to read mcp_settings.json: ${e.message}`)
+				}
+			}
+		}
+
+		for (const cmd of manifest.commands) {
+			if (!fsSync.existsSync(path.join(this.rooDir, "commands", cmd))) {
+				warnings.push(`command "${cmd}" missing`)
+			}
+		}
+
+		for (const skill of manifest.skills) {
+			if (!fsSync.existsSync(path.join(this.rooDir, "skills", skill))) {
+				warnings.push(`skill "${skill}" missing`)
+			}
+		}
+
+		for (const rule of manifest.rules) {
+			if (!fsSync.existsSync(path.join(this.rooDir, rule))) {
+				warnings.push(`rule "${rule}" missing`)
+			}
+		}
+
+		return warnings
+	}
+
+	private async verifyUninstalled(manifest: InstalledManifest | null): Promise<string[]> {
+		if (!manifest) return []
+		const warnings: string[] = []
+
+		if (manifest.agents.length > 0) {
+			const customModesPath = path.join(this.settingsDir || this.rooDir, "custom_modes.yaml")
+			if (fsSync.existsSync(customModesPath)) {
+				try {
+					const data = yaml.parse(fsSync.readFileSync(customModesPath, "utf-8"))
+					const slugs = new Set((data?.customModes || []).map((m: any) => m?.slug).filter(Boolean))
+					for (const slug of manifest.agents) {
+						if (slugs.has(slug)) warnings.push(`agent "${slug}" still present in custom_modes.yaml`)
+					}
+				} catch (e: any) {
+					warnings.push(`failed to read custom_modes.yaml: ${e.message}`)
+				}
+			}
+		}
+
+		if (manifest.mcp.length > 0) {
+			const mcpSettingsPath = path.join(this.settingsDir || this.rooDir, "mcp_settings.json")
+			if (fsSync.existsSync(mcpSettingsPath)) {
+				try {
+					const data = JSON.parse(fsSync.readFileSync(mcpSettingsPath, "utf-8"))
+					for (const name of manifest.mcp) {
+						if (data?.mcpServers?.[name]) warnings.push(`mcp server "${name}" still present`)
+					}
+				} catch (e: any) {
+					warnings.push(`failed to read mcp_settings.json: ${e.message}`)
+				}
+			}
+		}
+
+		for (const cmd of manifest.commands) {
+			if (fsSync.existsSync(path.join(this.rooDir, "commands", cmd))) {
+				warnings.push(`command "${cmd}" still present`)
+			}
+		}
+
+		for (const skill of manifest.skills) {
+			if (fsSync.existsSync(path.join(this.rooDir, "skills", skill))) {
+				warnings.push(`skill "${skill}" still present`)
+			}
+		}
+
+		for (const rule of manifest.rules) {
+			if (fsSync.existsSync(path.join(this.rooDir, rule))) {
+				warnings.push(`rule "${rule}" still present`)
+			}
+		}
+
+		return warnings
+	}
+
+	private assertPathSafe(target: string, root: string): void {
+		if (!isPathInside(target, root)) {
+			throw new FatalInstallerError("pathTraversal", `Path ${target} escapes root ${root}`)
+		}
+	}
+}

--- a/src/core/costrict/remote-agent-installer/AgentInstaller.ts
+++ b/src/core/costrict/remote-agent-installer/AgentInstaller.ts
@@ -350,7 +350,7 @@ export class AgentInstaller {
 			// on legitimate filenames like "..hidden" or "file..name".
 			// A traversal segment is exactly ".." (not "..hidden" or "file..name").
 			const segments = normalized.split("/")
-			if (segments.some((seg) => seg === "..") || normalized.startsWith("/")) {
+			if (segments.some((seg: string) => seg === "..") || normalized.startsWith("/")) {
 				throw new FatalInstallerError("pathTraversal", `Zip entry contains path traversal: ${entry.entryName}`)
 			}
 		}
@@ -607,10 +607,10 @@ export class AgentInstaller {
 				// Each top-level key is a server name; the value is the server config object.
 				// This matches the format used by mcp_settings.json and the actual zip packages.
 				for (const [serverName, serverConfig] of Object.entries(parsed)) {
-						if (!serverConfig || typeof serverConfig !== "object" || Object.keys(serverConfig).length === 0) {
-							logger.warn(`${LOG_PREFIX} Skipping invalid MCP server entry "${serverName}" in ${file}`)
-							continue
-						}
+					if (!serverConfig || typeof serverConfig !== "object" || Object.keys(serverConfig).length === 0) {
+						logger.warn(`${LOG_PREFIX} Skipping invalid MCP server entry "${serverName}" in ${file}`)
+						continue
+					}
 					settings.mcpServers[serverName] = serverConfig
 					serverNames.push(serverName)
 				}

--- a/src/core/costrict/remote-agent-installer/AgentInstaller.ts
+++ b/src/core/costrict/remote-agent-installer/AgentInstaller.ts
@@ -85,14 +85,14 @@ export async function atomicReplaceDirectory(src: string, dest: string): Promise
 				await fs.rm(src, { recursive: true, force: true })
 			} catch (cpError: any) {
 				if (hasBackup) {
-					await fs.rename(backup, dest).catch(() => {})
+					await restoreBackup(backup, dest)
 				}
 				throw cpError
 			}
 		} else {
 			// Restore backup to dest before re-throwing, so the original dest is not lost.
 			if (hasBackup) {
-				await fs.rename(backup, dest).catch(() => {})
+				await restoreBackup(backup, dest)
 			}
 			throw renameError
 		}
@@ -105,6 +105,21 @@ export async function atomicReplaceDirectory(src: string, dest: string): Promise
 		//    has succeeded, the backup is no longer needed and its cleanup is non-critical.
 		// 3. Awaiting this would delay the caller unnecessarily for a best-effort cleanup.
 		fs.rm(backup, { recursive: true, force: true }).catch(() => {})
+	}
+}
+
+/**
+ * Restore a backup directory to dest. On Windows, rename can fail with EPERM
+ * due to filesystem delays; fall back to cp+rm in that case.
+ */
+async function restoreBackup(backup: string, dest: string): Promise<void> {
+	try {
+		await fs.rename(backup, dest)
+	} catch (error: any) {
+		if (process.platform === "win32" && (error.code === "EPERM" || error.code === "EBUSY")) {
+			await fs.cp(backup, dest, { recursive: true }).catch(() => {})
+		}
+		// If rename fails for any other reason, dest may be lost — nothing more we can do.
 	}
 }
 
@@ -300,7 +315,7 @@ export class AgentInstaller {
 					`${LOG_PREFIX} Uninstallation verification warnings:\n${warnings.map((w) => `  - ${w}`).join("\n")}`,
 				)
 			} else {
-				logger.info(`${LOG_PREFIX} Uninstallation verified successfully`)
+				logger.info(`${LOG_PREFIX} Uninstallation verified: all files removed`)
 			}
 		} catch (error: any) {
 			logger.warn(`${LOG_PREFIX} Uninstallation verification failed unexpectedly: ${error.message}`)

--- a/src/core/costrict/remote-agent-installer/AgentInstaller.ts
+++ b/src/core/costrict/remote-agent-installer/AgentInstaller.ts
@@ -583,16 +583,22 @@ export class AgentInstaller {
 			// Path safety for zip contents is enforced by extractZip(); no additional check needed here.
 			try {
 				const content = await fs.readFile(filePath, "utf-8")
-				const serverConfig = JSON.parse(content)
-				if (!serverConfig || typeof serverConfig !== "object") {
+				const parsed = JSON.parse(content)
+				if (!parsed || typeof parsed !== "object") {
 					continue
 				}
-				const name = serverConfig.name || path.basename(file, ".json")
-				// Exclude the `name` field from the stored config — it's used as the key,
-				// not as part of the server configuration value in mcp_settings.json.
-				const { name: _name, ...serverConfigWithoutName } = serverConfig
-				settings.mcpServers[name] = serverConfigWithoutName
-				serverNames.push(name)
+				// MCP JSON files use the standard mcp_settings.json nested format:
+				//   { "serverName": { "type": "stdio", "command": "...", ... }, ... }
+				// Each top-level key is a server name; the value is the server config object.
+				// This matches the format used by mcp_settings.json and the actual zip packages.
+				for (const [serverName, serverConfig] of Object.entries(parsed)) {
+						if (!serverConfig || typeof serverConfig !== "object" || Object.keys(serverConfig).length === 0) {
+							logger.warn(`${LOG_PREFIX} Skipping invalid MCP server entry "${serverName}" in ${file}`)
+							continue
+						}
+					settings.mcpServers[serverName] = serverConfig
+					serverNames.push(serverName)
+				}
 			} catch (error: any) {
 				throw new FatalInstallerError("jsonParseError", `Failed to parse MCP JSON ${file}: ${error.message}`)
 			}

--- a/src/core/costrict/remote-agent-installer/InstallRecordManager.ts
+++ b/src/core/costrict/remote-agent-installer/InstallRecordManager.ts
@@ -1,0 +1,83 @@
+import * as fs from "fs/promises"
+import * as path from "path"
+import { createLogger } from "../../../utils/logger"
+import { Package } from "../../../shared/package"
+import { safeWriteJson } from "../../../utils/safeWriteJson"
+import { getGlobalCostrictDirectory } from "../../../services/roo-config/index"
+import { getCheckIntervalMs } from "./utils"
+import type { LocalInstallRecord } from "./types"
+
+const logger = createLogger(Package.outputChannel)
+const LOG_PREFIX = "[remote-agent-installer:record]"
+
+const CURRENT_SCHEMA_VERSION = 1
+
+const defaultRecord: LocalInstallRecord = {
+	schemaVersion: CURRENT_SCHEMA_VERSION,
+	installedVersion: "0.0.0",
+	lastCheckedAt: 0,
+	installState: "none",
+	manifest: {
+		agents: [],
+		commands: [],
+		skills: [],
+		rules: [],
+		mcp: [],
+	},
+}
+
+export class InstallRecordManager {
+	private recordPath: string
+
+	constructor(recordPath?: string) {
+		this.recordPath = recordPath || path.join(getGlobalCostrictDirectory(), "remote-agent-package.json")
+	}
+
+	async read(): Promise<LocalInstallRecord> {
+		try {
+			const data = await fs.readFile(this.recordPath, "utf-8")
+			const parsed = JSON.parse(data) as Partial<LocalInstallRecord>
+
+			if (!parsed.schemaVersion || parsed.schemaVersion !== CURRENT_SCHEMA_VERSION) {
+				logger.warn(`${LOG_PREFIX} Schema version mismatch or missing, resetting to default record`)
+				return { ...defaultRecord }
+			}
+
+			return {
+				schemaVersion: parsed.schemaVersion,
+				installedVersion: parsed.installedVersion || defaultRecord.installedVersion,
+				lastCheckedAt: parsed.lastCheckedAt ?? defaultRecord.lastCheckedAt,
+				installState: parsed.installState || defaultRecord.installState,
+				manifest: {
+					agents: parsed.manifest?.agents || [],
+					commands: parsed.manifest?.commands || [],
+					skills: parsed.manifest?.skills || [],
+					rules: parsed.manifest?.rules || [],
+					mcp: parsed.manifest?.mcp || [],
+				},
+			}
+		} catch (error: any) {
+			if (error.code === "ENOENT") {
+				return { ...defaultRecord }
+			}
+			logger.warn(`${LOG_PREFIX} Failed to read install record, using default: ${error.message}`)
+			return { ...defaultRecord }
+		}
+	}
+
+	async write(record: LocalInstallRecord): Promise<void> {
+		try {
+			await safeWriteJson(this.recordPath, record)
+		} catch (error: any) {
+			logger.error(`${LOG_PREFIX} Failed to write install record: ${error.message}`)
+			throw error
+		}
+	}
+
+	shouldCheck(record: LocalInstallRecord): boolean {
+		if (!record.lastCheckedAt) {
+			return true
+		}
+		return Date.now() - record.lastCheckedAt >= getCheckIntervalMs()
+	}
+}

--- a/src/core/costrict/remote-agent-installer/RemoteAgentInstaller.ts
+++ b/src/core/costrict/remote-agent-installer/RemoteAgentInstaller.ts
@@ -1,0 +1,491 @@
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as vscode from "vscode"
+import semverCompare from "semver-compare"
+import { createLogger } from "../../../utils/logger"
+import { Package } from "../../../shared/package"
+import { getGlobalCostrictDirectory } from "../../../services/roo-config/index"
+import { getSettingsDirectoryPath } from "../../../utils/storage"
+import { t } from "../../../i18n"
+import { InstallRecordManager } from "./InstallRecordManager"
+import { VersionApi } from "./VersionApi"
+import { AgentDownloader } from "./AgentDownloader"
+import { AgentInstaller } from "./AgentInstaller"
+import { delay, getCheckIntervalMs } from "./utils"
+import type {
+	ResourcePackageVersion,
+	LocalInstallRecord,
+	InstallResult,
+	UninstallResult,
+	InstalledManifest,
+} from "./types"
+import { FatalInstallerError } from "./types"
+
+const logger = createLogger(Package.outputChannel)
+const LOG_PREFIX = "[remote-agent-installer]"
+const LOCK_FILE_PATH = path.join(getGlobalCostrictDirectory(), "remote-agent-package.lock")
+const LOCK_EXPIRE_MS = 30 * 60 * 1000
+const OUTER_MAX_RETRIES = 3
+const OUTER_RETRY_DELAYS_MS = [1_000, 2_000, 4_000]
+
+export class RemoteAgentInstaller {
+	private static instance?: RemoteAgentInstaller
+	private context?: vscode.ExtensionContext
+	private recordManager: InstallRecordManager
+	private versionApi: VersionApi
+	private downloader: AgentDownloader
+	private installer: AgentInstaller
+	private runningPromise: Promise<InstallResult> | null = null
+	private checkTimeout?: NodeJS.Timeout
+	private statusBarItem?: vscode.StatusBarItem
+	private packageName: string = "Remote Resource Package"
+	private hasNotifiedFailure = false
+	private isDisposed = false
+
+	private constructor(context?: vscode.ExtensionContext) {
+		this.context = context
+		this.recordManager = new InstallRecordManager()
+		this.versionApi = new VersionApi()
+		this.downloader = new AgentDownloader()
+		this.installer = new AgentInstaller()
+	}
+
+	static getInstance(context?: vscode.ExtensionContext): RemoteAgentInstaller {
+		if (!RemoteAgentInstaller.instance) {
+			RemoteAgentInstaller.instance = new RemoteAgentInstaller(context)
+		} else if (context && !RemoteAgentInstaller.instance.context) {
+			// Update context on the existing instance if it was created without one.
+			// This handles the case where registerCommands.ts calls getInstance() without
+			// context before extension.ts calls getInstance(context) during activation.
+			// Without this update, ensureInstallerConfigured() would skip settingsDir
+			// configuration and AgentInstaller would use ~/.roo/ instead of globalStorageUri.
+			RemoteAgentInstaller.instance.context = context
+		}
+		return RemoteAgentInstaller.instance
+	}
+
+	/**
+	 * Dispose the singleton instance if it exists, without creating a new one.
+	 * Use this in extension deactivate() instead of getInstance().dispose() to
+	 * avoid accidentally creating a new instance just to immediately dispose it.
+	 */
+	static disposeInstance(): void {
+		RemoteAgentInstaller.instance?.dispose()
+	}
+
+	getPackageName(): string {
+		return this.packageName
+	}
+
+	scheduleBackgroundCheck(): void {
+		// FR-001: on activation, force an immediate check regardless of the 12h cooldown.
+		// The cooldown only applies to subsequent scheduled (timer-based) checks.
+		const run = async () => {
+			try {
+				await this.performBackgroundCheck(true)
+			} catch (error: any) {
+				logger.error(`${LOG_PREFIX} Background check error: ${error.message}`)
+			}
+			this.scheduleNextCheck()
+		}
+		void run()
+	}
+
+	async triggerManualInstall(): Promise<InstallResult> {
+		if (this.runningPromise) {
+			void vscode.window.showWarningMessage(
+				t("remoteAgentInstaller:warn.taskInProgress", { name: this.packageName }),
+			)
+			return { state: "failed", reason: "Task in progress" }
+		}
+
+		// NOTE: No race condition here despite the async gap between the runningPromise check
+		// and its assignment below. JavaScript is single-threaded: code between two `await`
+		// points runs atomically within the same event-loop tick. This method is only triggered
+		// by user-initiated VSCode commands, which are dispatched one at a time. A second
+		// invocation can only enter after the first `await` yields control, at which point
+		// `runningPromise` is already set. Multi-process concurrency (different VSCode windows)
+		// is handled separately by the file-based lock in doInstall().
+		await this.ensureInstallerConfigured()
+		const task = this.doInstall(true)
+		this.runningPromise = task
+		try {
+			const result = await task
+			return result
+		} finally {
+			this.runningPromise = null
+		}
+	}
+
+	async triggerManualUninstall(): Promise<UninstallResult> {
+		if (this.runningPromise) {
+			void vscode.window.showWarningMessage(
+				t("remoteAgentInstaller:warn.taskInProgress", { name: this.packageName }),
+			)
+			return { success: false, reason: "Task in progress" }
+		}
+
+		// Set runningPromise to block concurrent install/background-check during uninstall.
+		// runningPromise is typed as Promise<InstallResult> (not Promise<UninstallResult>) because
+		// it serves as a shared mutex for all task types (install, background-check, uninstall).
+		// Uninstall does not produce an InstallResult, so we create a dummy Promise<InstallResult>
+		// that resolves with { state: "noUpdate" } once the uninstall finishes. The resolved value
+		// is never consumed — only the presence/absence of runningPromise matters for the mutex.
+		let resolveRunning!: () => void
+		this.runningPromise = new Promise<InstallResult>((resolve) => {
+			resolveRunning = () => resolve({ state: "noUpdate" })
+		})
+
+		try {
+			await this.ensureInstallerConfigured()
+			const record = await this.recordManager.read()
+			await this.installer.uninstall(record)
+			await this.recordManager.write({
+				...record,
+				installedVersion: "0.0.0",
+				installState: "none",
+				manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+			})
+			return { success: true }
+		} catch (error: any) {
+			logger.error(`${LOG_PREFIX} Manual uninstall failed: ${error.message}`)
+			return { success: false, reason: error.message }
+		} finally {
+			resolveRunning()
+			this.runningPromise = null
+		}
+	}
+
+	dispose(): void {
+		this.isDisposed = true
+		if (this.checkTimeout) {
+			clearTimeout(this.checkTimeout)
+			this.checkTimeout = undefined
+		}
+		this.statusBarItem?.dispose()
+		this.releaseLock().catch(() => {})
+		// Clear the singleton instance so that getInstance() returns a fresh
+		// instance after dispose(), preventing use of a disposed/stale instance.
+		if (RemoteAgentInstaller.instance === this) {
+			RemoteAgentInstaller.instance = undefined
+		}
+	}
+
+	private async ensureInstallerConfigured(): Promise<void> {
+		if (this.context) {
+			const settingsDir = await getSettingsDirectoryPath(this.context.globalStorageUri.fsPath)
+			// Pass downloader.getTmpDir() so installer.tmpDir stays in sync with downloader.tmpDir.
+			// This ensures extractDir (computed from installer.tmpDir) is always in the same
+			// base directory as the downloaded zip file.
+			this.installer = new AgentInstaller(this.downloader.getTmpDir(), undefined, settingsDir)
+		}
+	}
+
+	private scheduleNextCheck(): void {
+		// Do not schedule if already disposed — avoids timer leaks after dispose().
+		if (this.isDisposed) {
+			return
+		}
+		const intervalMs = getCheckIntervalMs()
+		const nextCheckAt = new Date(Date.now() + intervalMs).toLocaleString()
+		logger.info(`${LOG_PREFIX} Next background check scheduled in ${intervalMs / 60_000} min (at ${nextCheckAt})`)
+		this.checkTimeout = setTimeout(() => {
+			// FR-002: timer-based checks respect the cooldown (forceCheck = false).
+			// The timer fires every `intervalMs`; shouldCheck() enforces the same cooldown so that
+			// if a check was already performed recently (e.g. on activation), this timer
+			// check is skipped without making a network request.
+			// The interval defaults to 12h and can be overridden via
+			// COSTRICT_AGENT_CHECK_INTERVAL_MINUTES (minimum 1 minute, for testing).
+			const run = async () => {
+				try {
+					await this.performBackgroundCheck(false)
+				} catch (error: any) {
+					logger.error(`${LOG_PREFIX} Background check error: ${error.message}`)
+				}
+				this.scheduleNextCheck()
+			}
+			void run()
+		}, intervalMs)
+	}
+
+	// forceCheck=true skips the 12h cooldown (used on activation per FR-001).
+	// forceCheck=false respects the cooldown (used by timer-based checks per FR-002).
+	private async performBackgroundCheck(forceCheck: boolean): Promise<void> {
+		if (this.runningPromise) {
+			logger.info(`${LOG_PREFIX} Background check skipped, install task already running`)
+			return
+		}
+		const record = await this.recordManager.read()
+		if (!forceCheck && !this.recordManager.shouldCheck(record)) {
+			logger.info(`${LOG_PREFIX} Skipping background check, cooldown active`)
+			return
+		}
+		const task = this.doInstall(false)
+		this.runningPromise = task
+		try {
+			await task
+		} catch (error: any) {
+			// doInstall throws on network/HTTP errors (VersionApi throws instead of returning null).
+			// Swallow the error here so lastCheckedAt is NOT updated on network failures —
+			// the background check will be retried on the next scheduled interval.
+			logger.warn(`${LOG_PREFIX} Background version check failed: ${error.message}`)
+		} finally {
+			this.runningPromise = null
+		}
+	}
+
+	private async doInstall(isManual: boolean): Promise<InstallResult> {
+		const record = await this.recordManager.read()
+
+		// getLatestVersion() throws on network/HTTP errors; returns null only when the server
+		// responds OK but has no downloadUrl (no package available). lastCheckedAt must NOT
+		// be updated on network errors — only on successful checks.
+		const versionInfo = await this.versionApi.getLatestVersion()
+
+		if (!versionInfo) {
+			logger.info(`${LOG_PREFIX} No remote resource package available`)
+			await this.updateLastChecked(record)
+			return { state: "noUpdate" }
+		}
+
+		this.packageName = versionInfo.name || "Remote Resource Package"
+
+		if (semverCompare(versionInfo.version, record.installedVersion) <= 0) {
+			logger.info(`${LOG_PREFIX} Local version ${record.installedVersion} is up to date`)
+			await this.updateLastChecked(record)
+			return { state: "noUpdate" }
+		}
+
+		logger.info(
+			`${LOG_PREFIX} ${this.packageName} remote: ${versionInfo.version}, local: ${record.installedVersion}, update needed`,
+		)
+
+		// Check lock for both manual and background triggers
+		const lockHeld = await this.isLockHeld()
+		if (lockHeld) {
+			if (isManual) {
+				logger.warn(`${LOG_PREFIX} Lock held by another process, cannot start manual install`)
+				// Lock held → install skipped entirely. Do NOT update lastCheckedAt here:
+				// resetting the 12h cooldown would cause the next window to skip the check
+				// even though no install was actually attempted in this window.
+				return { state: "failed", reason: "Another process is currently installing" }
+			}
+			logger.warn(`${LOG_PREFIX} Lock held by another process, skipping background check`)
+			// Same reasoning: do NOT update lastCheckedAt when install was skipped due to lock.
+			return { state: "noUpdate" }
+		}
+
+		try {
+			await this.acquireLock()
+		} catch (error: any) {
+			// EEXIST means another process just acquired the lock between our check and acquire (TOCTOU race)
+			if (error.code === "EEXIST") {
+				logger.warn(`${LOG_PREFIX} Lock already held by another process (race condition), skipping`)
+				if (isManual) {
+					return { state: "failed", reason: "Another process is currently installing" }
+				}
+				return { state: "noUpdate" }
+			}
+			logger.warn(`${LOG_PREFIX} Failed to acquire lock: ${error.message}`)
+			if (isManual) {
+				return { state: "failed", reason: "Failed to acquire lock" }
+			}
+			return { state: "noUpdate" }
+		}
+
+		try {
+			await this.ensureInstallerConfigured()
+			// Re-read the record after acquiring the lock to avoid stale version comparison
+			// in multi-process scenarios (another window may have already installed the update).
+			const freshRecord = await this.recordManager.read()
+			if (semverCompare(versionInfo.version, freshRecord.installedVersion) <= 0) {
+				logger.info(`${LOG_PREFIX} Version already up to date after acquiring lock, skipping install`)
+				// Update lastCheckedAt so the 12h cooldown is correctly reset.
+				// Without this, the next activation would re-check immediately instead of waiting 12h.
+				await this.updateLastChecked(freshRecord)
+				return { state: "noUpdate" }
+			}
+			return await this.runInstallWithRetries(versionInfo, freshRecord, isManual)
+		} finally {
+			await this.releaseLock()
+		}
+	}
+
+	private async runInstallWithRetries(
+		versionInfo: ResourcePackageVersion,
+		record: LocalInstallRecord,
+		isManual: boolean,
+	): Promise<InstallResult> {
+		// Reset hasNotifiedFailure at the start of each new install attempt so that
+		// each background failure cycle can independently notify the user.
+		this.hasNotifiedFailure = false
+		let lastError: Error | undefined
+		let zipPath: string | undefined
+		const extractDir = path.join(this.installer.getTmpDir(), `remote-agent-package-${versionInfo.version}`)
+
+		for (let attempt = 0; attempt < OUTER_MAX_RETRIES; attempt++) {
+			try {
+				// Reuse the zip from a previous successful download() call if it still exists.
+				// Note: download() calls cleanupResidualFiles() internally, which deletes ALL
+				// agent-package-* files. This is safe because:
+				//   - On attempt 0: zipPath is undefined, so download() is always called.
+				//   - On attempt 1+: zipPath points to the file returned by the previous download().
+				//     Since download() only returns after writing the file, the file exists.
+				//     cleanupResidualFiles() is only called at the START of download(), so it
+				//     cannot delete a zip that was returned by a prior download() call.
+				if (!zipPath || !(await this.fileExists(zipPath))) {
+					zipPath = await this.downloader.download(versionInfo, (progress) => {
+						this.showDownloadProgress(progress.progress)
+					})
+				}
+
+				const manifest = await this.installer.install(zipPath, versionInfo, record)
+				await this.recordManager.write({
+					...record,
+					installedVersion: versionInfo.version,
+					lastCheckedAt: Date.now(),
+					installState: "installed",
+					manifest,
+				})
+				this.hideDownloadProgress()
+				this.hasNotifiedFailure = false
+				logger.info(`${LOG_PREFIX} ${this.packageName} updated to ${versionInfo.version}`)
+				if (!isManual) {
+					void vscode.window.showInformationMessage(
+						t("remoteAgentInstaller:info.installed", {
+							name: this.packageName,
+							version: versionInfo.version,
+						}),
+					)
+				}
+				return { state: "installed", version: versionInfo.version }
+			} catch (error: any) {
+				lastError = error
+				logger.warn(`${LOG_PREFIX} Install attempt ${attempt + 1} failed: ${error.message}`)
+
+				if (error instanceof FatalInstallerError) {
+					this.hideDownloadProgress()
+					await this.installer.cleanup(zipPath, extractDir)
+					if (!isManual) {
+						this.notifyFatalError(error)
+					}
+					return { state: "failed", reason: error.message }
+				}
+
+				if (attempt < OUTER_MAX_RETRIES - 1) {
+					await this.installer.cleanup(undefined, extractDir)
+					await delay(OUTER_RETRY_DELAYS_MS[attempt])
+				} else {
+					this.hideDownloadProgress()
+					await this.installer.cleanup(zipPath, extractDir)
+					// lastCheckedAt is only updated on a successful version check, not on install failure.
+					await this.recordManager.write({
+						...record,
+						installState: "failed",
+					})
+					if (!isManual && lastError) {
+						this.notifyRetryableError(lastError)
+					}
+					return { state: "failed", reason: lastError?.message || "Unknown error" }
+				}
+			}
+		}
+
+		return { state: "failed", reason: lastError?.message || "Unknown error" }
+	}
+
+	private async updateLastChecked(record: LocalInstallRecord): Promise<void> {
+		await this.recordManager.write({
+			...record,
+			lastCheckedAt: Date.now(),
+		})
+	}
+
+	private showDownloadProgress(percentage: number): void {
+		if (!this.statusBarItem) {
+			this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100)
+		}
+		this.statusBarItem.text = `$(cloud-download) ${this.packageName} ${percentage}%`
+		this.statusBarItem.show()
+	}
+
+	private hideDownloadProgress(): void {
+		this.statusBarItem?.hide()
+	}
+
+	private async isLockHeld(): Promise<boolean> {
+		try {
+			const data = await fs.readFile(LOCK_FILE_PATH, "utf-8")
+			const lock = JSON.parse(data) as { pid: number; startTime: number }
+			if (Date.now() - lock.startTime < LOCK_EXPIRE_MS) {
+				return true
+			}
+			await fs.unlink(LOCK_FILE_PATH).catch(() => {})
+			return false
+		} catch {
+			return false
+		}
+	}
+
+	private async acquireLock(): Promise<void> {
+		const lockData = JSON.stringify({ pid: process.pid, startTime: Date.now() })
+		await fs.mkdir(path.dirname(LOCK_FILE_PATH), { recursive: true })
+		// Use exclusive write (wx flag) to prevent concurrent lock acquisition
+		await fs.writeFile(LOCK_FILE_PATH, lockData, { encoding: "utf-8", flag: "wx" })
+	}
+
+	private async releaseLock(): Promise<void> {
+		try {
+			await fs.unlink(LOCK_FILE_PATH)
+		} catch {
+			// ignore
+		}
+	}
+
+	private notifyFatalError(error: FatalInstallerError): void {
+		if (this.hasNotifiedFailure) {
+			return
+		}
+		this.hasNotifiedFailure = true
+		void vscode.window.showWarningMessage(
+			t("remoteAgentInstaller:warn.contentCorrupted", { name: this.packageName }),
+		)
+	}
+
+	private notifyRetryableError(error: Error): void {
+		if (this.hasNotifiedFailure) {
+			return
+		}
+		this.hasNotifiedFailure = true
+		const code = (error as any).code || ""
+		const isNetwork = ["ETIMEDOUT", "ECONNREFUSED", "ENOTFOUND", "EAI_AGAIN"].includes(code)
+
+		// Network errors show a "download failed" message; all other errors (disk, unknown, etc.)
+		// show an "install failed" message. Both offer a "Retry Now" button.
+		const messageKey = isNetwork
+			? "remoteAgentInstaller:warn.downloadFailed"
+			: "remoteAgentInstaller:warn.installFailed"
+		void vscode.window
+			.showWarningMessage(
+				t(messageKey, {
+					name: this.packageName,
+					reason: error.message,
+				}),
+				t("remoteAgentInstaller:action.retryNow"),
+			)
+			.then((selection) => {
+				if (selection === t("remoteAgentInstaller:action.retryNow")) {
+					void this.triggerManualInstall()
+				}
+			})
+	}
+
+	private async fileExists(filePath: string): Promise<boolean> {
+		try {
+			await fs.access(filePath)
+			return true
+		} catch {
+			return false
+		}
+	}
+}

--- a/src/core/costrict/remote-agent-installer/RemoteAgentInstaller.ts
+++ b/src/core/costrict/remote-agent-installer/RemoteAgentInstaller.ts
@@ -167,6 +167,7 @@ export class RemoteAgentInstaller {
 		try {
 			await this.ensureInstallerConfigured()
 			const record = await this.recordManager.read()
+			logger.info(`${LOG_PREFIX} Uninstalling ${this.packageName} ${record.installedVersion}`)
 			await this.installer.uninstall(record)
 			await this.recordManager.write({
 				...record,
@@ -174,6 +175,8 @@ export class RemoteAgentInstaller {
 				installState: "none",
 				manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
 			})
+			logger.info(`${LOG_PREFIX} ${this.packageName} ${record.installedVersion} uninstalled successfully`)
+			void this.hotReloadAfterInstall()
 			return { success: true }
 		} catch (error: any) {
 			logger.error(`${LOG_PREFIX} Manual uninstall failed: ${error.message}`)

--- a/src/core/costrict/remote-agent-installer/RemoteAgentInstaller.ts
+++ b/src/core/costrict/remote-agent-installer/RemoteAgentInstaller.ts
@@ -7,6 +7,8 @@ import { Package } from "../../../shared/package"
 import { getGlobalCostrictDirectory } from "../../../services/roo-config/index"
 import { getSettingsDirectoryPath } from "../../../utils/storage"
 import { t } from "../../../i18n"
+// costrict: import ClineProvider for hot-reload after install
+import { ClineProvider } from "../../webview/ClineProvider"
 import { InstallRecordManager } from "./InstallRecordManager"
 import { VersionApi } from "./VersionApi"
 import { AgentDownloader } from "./AgentDownloader"
@@ -75,6 +77,32 @@ export class RemoteAgentInstaller {
 
 	getPackageName(): string {
 		return this.packageName
+	}
+
+	/**
+	 * Force an immediate background check without rescheduling the timer.
+	 *
+	 * Use this when an out-of-band event (e.g. costrictBaseUrl changed) requires
+	 * an immediate version check. The existing background check cycle (managed by
+	 * scheduleNextCheck) is left untouched to avoid delaying or resetting the
+	 * regular 12h interval.
+	 *
+	 * Calls `performBackgroundCheck(true)` where `true` means **forceCheck** —
+	 * i.e. skip the 12h cooldown so the check runs immediately regardless of when
+	 * the last check occurred. This is NOT the same as `isManual`: the check still
+	 * runs as a background (non-manual) operation, so `doInstall(false)` is called
+	 * internally and the `noUpdate` result is silenced per FR-005.
+	 */
+	forceBackgroundCheck(): void {
+		logger.info(`${LOG_PREFIX} forceBackgroundCheck triggered (costrictBaseUrl changed)`)
+		const run = async () => {
+			try {
+				await this.performBackgroundCheck(true)
+			} catch (error: any) {
+				logger.error(`${LOG_PREFIX} Force background check error: ${error.message}`)
+			}
+		}
+		void run()
 	}
 
 	scheduleBackgroundCheck(): void {
@@ -251,7 +279,7 @@ export class RemoteAgentInstaller {
 		this.packageName = versionInfo.name || "Remote Resource Package"
 
 		if (semverCompare(versionInfo.version, record.installedVersion) <= 0) {
-			logger.info(`${LOG_PREFIX} Local version ${record.installedVersion} is up to date`)
+			logger.info(`${LOG_PREFIX} Local version ${record.installedVersion} is up to date, skipping installation.`)
 			await this.updateLastChecked(record)
 			return { state: "noUpdate" }
 		}
@@ -350,6 +378,9 @@ export class RemoteAgentInstaller {
 				this.hideDownloadProgress()
 				this.hasNotifiedFailure = false
 				logger.info(`${LOG_PREFIX} ${this.packageName} updated to ${versionInfo.version}`)
+				// costrict: hot-reload custom modes, skills after install
+				void this.hotReloadAfterInstall()
+				// Background install shows notification here; manual install notification is handled by registerCommands.ts
 				if (!isManual) {
 					void vscode.window.showInformationMessage(
 						t("remoteAgentInstaller:info.installed", {
@@ -411,6 +442,29 @@ export class RemoteAgentInstaller {
 
 	private hideDownloadProgress(): void {
 		this.statusBarItem?.hide()
+	}
+
+	// hot-reload custom modes, skills after a successful remote agent install.
+	// Invalidates the ClineProvider's in-memory custom modes cache and re-discovers skills so that
+	// newly installed agents and skills are immediately visible in the UI without a VSCode restart.
+	private async hotReloadAfterInstall(): Promise<void> {
+		logger.info(`${LOG_PREFIX} Starting hot-reload after install (customModes, skills)`)
+		try {
+			const provider = await ClineProvider.getInstance()
+			if (!provider) {
+				logger.warn(`${LOG_PREFIX} Hot-reload skipped: no active ClineProvider instance`)
+				return
+			}
+			// Invalidate custom modes cache so the next getState() re-reads custom_modes.yaml
+			provider.invalidateCustomModesCache()
+			// Re-discover skills from disk (also refreshes the commands list)
+			await provider.getSkillsManager()?.discoverSkills()
+			// Push updated state to webview so the mode dropdown updates immediately
+			await provider.postStateToWebviewWithoutClineMessages()
+			logger.info(`${LOG_PREFIX} Hot-reload completed: webview state pushed`)
+		} catch (error: any) {
+			logger.warn(`${LOG_PREFIX} hotReloadAfterInstall failed (non-blocking): ${error.message}`)
+		}
 	}
 
 	private async isLockHeld(): Promise<boolean> {

--- a/src/core/costrict/remote-agent-installer/RemoteAgentInstaller.ts
+++ b/src/core/costrict/remote-agent-installer/RemoteAgentInstaller.ts
@@ -85,10 +85,10 @@ export class RemoteAgentInstaller {
 	 * Use this when an out-of-band event (e.g. costrictBaseUrl changed) requires
 	 * an immediate version check. The existing background check cycle (managed by
 	 * scheduleNextCheck) is left untouched to avoid delaying or resetting the
-	 * regular 12h interval.
+	 * regular check interval.
 	 *
 	 * Calls `performBackgroundCheck(true)` where `true` means **forceCheck** —
-	 * i.e. skip the 12h cooldown so the check runs immediately regardless of when
+	 * i.e. skip the check cooldown so the check runs immediately regardless of when
 	 * the last check occurred. This is NOT the same as `isManual`: the check still
 	 * runs as a background (non-manual) operation, so `doInstall(false)` is called
 	 * internally and the `noUpdate` result is silenced per FR-005.
@@ -106,7 +106,7 @@ export class RemoteAgentInstaller {
 	}
 
 	scheduleBackgroundCheck(): void {
-		// FR-001: on activation, force an immediate check regardless of the 12h cooldown.
+		// FR-001: on activation, force an immediate check regardless of the cooldown.
 		// The cooldown only applies to subsequent scheduled (timer-based) checks.
 		const run = async () => {
 			try {
@@ -225,8 +225,7 @@ export class RemoteAgentInstaller {
 			// The timer fires every `intervalMs`; shouldCheck() enforces the same cooldown so that
 			// if a check was already performed recently (e.g. on activation), this timer
 			// check is skipped without making a network request.
-			// The interval defaults to 12h and can be overridden via
-			// COSTRICT_AGENT_CHECK_INTERVAL_MINUTES (minimum 1 minute, for testing).
+			// The interval can be overridden via COSTRICT_AGENT_CHECK_INTERVAL_MINUTES (minimum 1 minute).
 			const run = async () => {
 				try {
 					await this.performBackgroundCheck(false)
@@ -239,7 +238,7 @@ export class RemoteAgentInstaller {
 		}, intervalMs)
 	}
 
-	// forceCheck=true skips the 12h cooldown (used on activation per FR-001).
+	// forceCheck=true skips the cooldown (used on activation per FR-001).
 	// forceCheck=false respects the cooldown (used by timer-based checks per FR-002).
 	private async performBackgroundCheck(forceCheck: boolean): Promise<void> {
 		if (this.runningPromise) {
@@ -297,7 +296,7 @@ export class RemoteAgentInstaller {
 			if (isManual) {
 				logger.warn(`${LOG_PREFIX} Lock held by another process, cannot start manual install`)
 				// Lock held → install skipped entirely. Do NOT update lastCheckedAt here:
-				// resetting the 12h cooldown would cause the next window to skip the check
+				// resetting the cooldown would cause the next window to skip the check
 				// even though no install was actually attempted in this window.
 				return { state: "failed", reason: "Another process is currently installing" }
 			}
@@ -331,8 +330,8 @@ export class RemoteAgentInstaller {
 			const freshRecord = await this.recordManager.read()
 			if (semverCompare(versionInfo.version, freshRecord.installedVersion) <= 0) {
 				logger.info(`${LOG_PREFIX} Version already up to date after acquiring lock, skipping install`)
-				// Update lastCheckedAt so the 12h cooldown is correctly reset.
-				// Without this, the next activation would re-check immediately instead of waiting 12h.
+				// Update lastCheckedAt so the cooldown is correctly reset.
+				// Without this, the next activation would re-check immediately instead of waiting for the interval.
 				await this.updateLastChecked(freshRecord)
 				return { state: "noUpdate" }
 			}

--- a/src/core/costrict/remote-agent-installer/VersionApi.ts
+++ b/src/core/costrict/remote-agent-installer/VersionApi.ts
@@ -1,0 +1,155 @@
+import { ClineProvider } from "../../webview/ClineProvider"
+import { createLogger } from "../../../utils/logger"
+import { Package } from "../../../shared/package"
+import { COSTRICT_DEFAULT_HEADERS } from "../../../shared/headers"
+import { v7 as uuidv7 } from "uuid"
+import { redactUrl } from "./utils"
+import type { ResourcePackageVersion } from "./types"
+import { CostrictAuthConfig } from "../../../core/costrict/auth"
+
+const logger = createLogger(Package.outputChannel)
+const LOG_PREFIX = "[remote-agent-installer]"
+
+const VERSION_TIMEOUT_MS = 30_000
+
+function isValidSemVer(version: string): boolean {
+	return /^\d+\.\d+\.\d+$/.test(version)
+}
+
+export class VersionApi {
+	/**
+	 * Fetch the latest resource package version from the server.
+	 *
+	 * Returns:
+	 *   - `ResourcePackageVersion` — a new version is available for download
+	 *   - `null` — the server responded successfully but no package is available
+	 *     (downloadUrl is absent/empty, or costrictBaseUrl is not configured).
+	 *     The caller should update lastCheckedAt and silently skip the update.
+	 *
+	 * Throws:
+	 *   - Any network/HTTP error (timeout, connection refused, non-2xx status,
+	 *     invalid JSON, invalid semver, etc.). The caller must NOT update
+	 *     lastCheckedAt in this case, because no successful check occurred.
+	 */
+	async getLatestVersion(): Promise<ResourcePackageVersion | null> {
+		const baseUrl = await this.getBaseUrl()
+
+		if (!baseUrl) {
+			logger.info(`${LOG_PREFIX} Skipping version check: costrictBaseUrl is not configured`)
+			return null
+		}
+
+		const url = `${baseUrl}/costrict-static/agent-package/latest.json`
+
+		logger.info(`${LOG_PREFIX} Checking latest version from ${redactUrl(url)}`)
+
+		const controller = new AbortController()
+		const timeout = setTimeout(() => controller.abort(), VERSION_TIMEOUT_MS)
+
+		let response: Response
+		try {
+			const headers = await this.getRequestHeaders()
+			response = await fetch(url, {
+				method: "GET",
+				headers,
+				signal: controller.signal,
+			})
+		} catch (error: any) {
+			clearTimeout(timeout)
+			if (error.name === "AbortError") {
+				logger.warn(`${LOG_PREFIX} Version API request timed out after ${VERSION_TIMEOUT_MS}ms`)
+				throw new Error(`Version API request timed out after ${VERSION_TIMEOUT_MS}ms`)
+			}
+			logger.warn(`${LOG_PREFIX} Failed to fetch latest version: ${error.message}`)
+			throw error
+		}
+
+		clearTimeout(timeout)
+
+		if (!response.ok) {
+			logger.warn(`${LOG_PREFIX} Version API returned status ${response.status}`)
+			throw new Error(`Version API returned HTTP ${response.status}`)
+		}
+
+		let data: ResourcePackageVersion
+		try {
+			data = (await response.json()) as ResourcePackageVersion
+		} catch (error: any) {
+			logger.warn(`${LOG_PREFIX} Failed to parse version API response: ${error.message}`)
+			throw new Error(`Failed to parse version API response: ${error.message}`)
+		}
+
+		if (!data.version || !isValidSemVer(data.version)) {
+			logger.warn(`${LOG_PREFIX} Invalid or missing version in response: ${data.version}`)
+			throw new Error(`Invalid or missing version in response: ${data.version}`)
+		}
+
+		if (!data.downloadUrl) {
+			// Server responded successfully but no package is available — silent skip.
+			// Caller should update lastCheckedAt to record that a successful check occurred.
+			logger.info(`${LOG_PREFIX} No downloadUrl provided, skipping resource package update`)
+			return null
+		}
+
+		const resolved: ResourcePackageVersion = {
+			name: data.name,
+			version: data.version,
+			downloadUrl: this.resolveUrl(data.downloadUrl, baseUrl),
+			checksum: data.checksum,
+			checksumAlgo: data.checksumAlgo,
+		}
+
+		logger.info(`${LOG_PREFIX} Remote version: ${resolved.version}, url: ${redactUrl(resolved.downloadUrl || "")}`)
+		return resolved
+	}
+
+	private async getBaseUrl(): Promise<string> {
+		const provider = await ClineProvider.getInstance()
+		if (!provider) {
+			return ""
+		}
+		try {
+			let apiConfiguration = (await provider.getState()).apiConfiguration
+			return apiConfiguration.costrictBaseUrl?.trim() || "" // not use default value here
+		} catch {
+			// ignore
+		}
+		return ""
+	}
+
+	private async getRequestHeaders(): Promise<Record<string, string>> {
+		try {
+			const provider = await ClineProvider.getInstance()
+			if (!provider) {
+				return {}
+			}
+			const currentName = provider.getValue("currentApiConfigName") || "default"
+			const profile = await provider.providerSettingsManager.getProfile({ name: currentName })
+			const headers: Record<string, string> = {
+				"Content-Type": "application/json",
+				"X-Request-ID": uuidv7(),
+				"Accept-Language": provider.getValue("language") || "",
+				...COSTRICT_DEFAULT_HEADERS,
+			}
+			if (profile.costrictAccessToken) {
+				headers["Authorization"] = `Bearer ${profile.costrictAccessToken}`
+			}
+			return headers
+		} catch {
+			// ignore header errors
+		}
+		return {}
+	}
+
+	private resolveUrl(downloadUrl: string, baseUrl: string): string {
+		if (!downloadUrl) {
+			return ""
+		}
+		if (downloadUrl.startsWith("http://") || downloadUrl.startsWith("https://")) {
+			return downloadUrl
+		}
+		const base = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+		const path = downloadUrl.startsWith("/") ? downloadUrl : `/${downloadUrl}`
+		return `${base}${path}`
+	}
+}

--- a/src/core/costrict/remote-agent-installer/VersionApi.ts
+++ b/src/core/costrict/remote-agent-installer/VersionApi.ts
@@ -110,7 +110,7 @@ export class VersionApi {
 		}
 		try {
 			let apiConfiguration = (await provider.getState()).apiConfiguration
-			return apiConfiguration.costrictBaseUrl?.trim() || "" // not use default value here
+			return apiConfiguration.costrictBaseUrl?.trim() || CostrictAuthConfig.getInstance().getDefaultApiBaseUrl()
 		} catch {
 			// ignore
 		}

--- a/src/core/costrict/remote-agent-installer/__tests__/AgentDownloader.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/AgentDownloader.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest"
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as os from "os"
+import * as http from "http"
+import { allowNetConnect } from "../../../../vitest.setup"
+import { AgentDownloader } from "../AgentDownloader"
+import type { ResourcePackageVersion } from "../types"
+import { FatalInstallerError } from "../types"
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}))
+
+describe("AgentDownloader", () => {
+	let tmpDir: string
+	let downloader: AgentDownloader
+
+	beforeAll(() => {
+		// Allow local HTTP server connections (nock blocks all by default)
+		allowNetConnect("127.0.0.1")
+	})
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `rd-test-${Date.now()}`)
+		await fs.mkdir(tmpDir, { recursive: true })
+		downloader = new AgentDownloader(tmpDir)
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("should throw when download fails", async () => {
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: "http://localhost:99999/nonexistent",
+		}
+		await expect(downloader.download(versionInfo)).rejects.toThrow()
+	})
+
+	it("should cleanup residual files", async () => {
+		await fs.writeFile(path.join(tmpDir, "remote-agent-package-1.0.0.zip"), "old", "utf-8")
+		await fs.writeFile(path.join(tmpDir, "remote-agent-package-1.0.0.zip.downloading"), "old", "utf-8")
+		await downloader.cleanupResidualFiles("1.0.0")
+		const entries = await fs.readdir(tmpDir)
+		expect(entries.filter((e) => e.includes("1.0.0")).length).toBe(0)
+	})
+
+	// Bug1 regression: cleanupResidualFiles should clean ALL remote-agent-package-* files,
+	// including files from other versions (not just the current version).
+	it("should cleanup residual files from other versions", async () => {
+		await fs.writeFile(path.join(tmpDir, "remote-agent-package-0.9.0.zip"), "old", "utf-8")
+		await fs.writeFile(path.join(tmpDir, "remote-agent-package-0.9.0.zip.downloading"), "old", "utf-8")
+		await fs.writeFile(path.join(tmpDir, "remote-agent-package-2.0.0.zip"), "newer", "utf-8")
+		await fs.writeFile(path.join(tmpDir, "unrelated-file.txt"), "keep", "utf-8")
+		await downloader.cleanupResidualFiles("1.0.0")
+		const entries = await fs.readdir(tmpDir)
+		// All remote-agent-package-* files should be removed regardless of version
+		expect(entries.filter((e) => e.startsWith("remote-agent-package-")).length).toBe(0)
+		// Unrelated files should be preserved
+		expect(entries).toContain("unrelated-file.txt")
+	})
+
+	// Bug1 regression: cleanupResidualFiles should also clean the current version's zip
+	// (it is called at the start of download() to clear stale files from previous runs).
+	it("should cleanup current version zip file as well", async () => {
+		await fs.writeFile(path.join(tmpDir, "remote-agent-package-1.0.0.zip"), "stale", "utf-8")
+		await downloader.cleanupResidualFiles("1.0.0")
+		const entries = await fs.readdir(tmpDir)
+		expect(entries).not.toContain("remote-agent-package-1.0.0.zip")
+	})
+
+	// BUG-6 regression: checksum mismatch must throw FatalInstallerError (not plain Error)
+	// so that the outer retry logic stops immediately instead of retrying 3 times.
+	it("should throw FatalInstallerError on checksum mismatch", async () => {
+		// Start a local HTTP server that serves a real file
+		const server = http.createServer((req, res) => {
+			const data = Buffer.from("fake zip content")
+			res.writeHead(200, { "Content-Type": "application/zip", "Content-Length": data.length })
+			res.end(data)
+		})
+
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()))
+		const addr = server.address() as { port: number }
+		const port = addr.port
+
+		try {
+			const versionInfo: ResourcePackageVersion = {
+				version: "1.0.0",
+				downloadUrl: `http://127.0.0.1:${port}/remote-agent-package-1.0.0.zip`,
+				checksum: "0000000000000000000000000000000000000000000000000000000000000000",
+				checksumAlgo: "sha256",
+			}
+
+			// Must throw FatalInstallerError, not plain Error
+			await expect(downloader.download(versionInfo)).rejects.toThrow(FatalInstallerError)
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()))
+		}
+	})
+
+	// Simplification: AgentDownloader no longer retries internally.
+	// All retry logic is handled by the outer RemoteAgentInstaller.runInstallWithRetries.
+	// This ensures the total retry count is exactly 3 (FR-014), not 3×3=9.
+	it("should NOT retry internally — fail immediately on first download error", async () => {
+		let callCount = 0
+		const server = http.createServer((req, res) => {
+			callCount++
+			res.writeHead(500, { "Content-Type": "text/plain" })
+			res.end("Internal Server Error")
+		})
+
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()))
+		const addr = server.address() as { port: number }
+		const port = addr.port
+
+		try {
+			const versionInfo: ResourcePackageVersion = {
+				version: "1.0.0",
+				downloadUrl: `http://127.0.0.1:${port}/remote-agent-package-1.0.0.zip`,
+			}
+
+			await expect(downloader.download(versionInfo)).rejects.toThrow()
+			// Must only attempt once — no internal retry
+			expect(callCount).toBe(1)
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()))
+		}
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/AgentInstaller.edge.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/AgentInstaller.edge.test.ts
@@ -227,7 +227,8 @@ describe("AgentInstaller edge cases", () => {
 		const zipPath = path.join(tmpDir, "settings-dir.zip")
 		await createZipWithModules(zipPath, {
 			agents: "name: SettingsDir Agent\nslug: settings-agent\n",
-			mcp: JSON.stringify({ name: "settings-server", url: "http://localhost" }),
+			// use nested format (standard mcp_settings.json format)
+			mcp: JSON.stringify({ "settings-server": { url: "http://localhost" } }),
 		})
 
 		const settingsDir = path.join(tmpDir, "settings")
@@ -339,7 +340,8 @@ describe("AgentInstaller edge cases", () => {
 	it("should warn and continue when local mcp_settings.json is corrupted (not FatalError)", async () => {
 		const zipPath = path.join(tmpDir, "mcp-test.zip")
 		await createZipWithModules(zipPath, {
-			mcp: JSON.stringify({ name: "test-server", url: "http://localhost:3000" }),
+			// use nested format (standard mcp_settings.json format)
+			mcp: JSON.stringify({ "test-server": { url: "http://localhost:3000" } }),
 		})
 
 		const installer = new AgentInstaller(tmpDir, rooDir)

--- a/src/core/costrict/remote-agent-installer/__tests__/AgentInstaller.edge.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/AgentInstaller.edge.test.ts
@@ -1,0 +1,881 @@
+/**
+ * AgentInstaller edge case tests.
+ * Covers: partial modules, path traversal, skill placeholder replacement, manifest validation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import * as path from "path"
+import * as os from "os"
+import { AgentInstaller } from "../AgentInstaller"
+import { FatalInstallerError } from "../types"
+import type { LocalInstallRecord, ResourcePackageVersion } from "../types"
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		channel: { appendLine: vi.fn() },
+	}),
+}))
+
+vi.mock("../../../utils/safeWriteJson", () => ({
+	safeWriteJson: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Helper: create a zip with specified modules
+// modules: { moduleName: fileContentString | { fileName: fileContent } }
+// For skills, the value can be nested: { "skill-dir": { "file.md": "content" } }
+async function createZipWithModules(destPath: string, modules: Record<string, any>, version = "1.0.0"): Promise<void> {
+	const AdmZip = (await import("adm-zip")).default
+	const zip = new AdmZip()
+
+	const srcDir = path.join(path.dirname(destPath), "zip-src-" + Date.now())
+	await fs.mkdir(srcDir, { recursive: true })
+
+	// Always create manifest
+	const manifestModules = Object.keys(modules)
+	await fs.writeFile(
+		path.join(srcDir, "manifest.json"),
+		JSON.stringify({ version, modules: manifestModules }),
+		"utf-8",
+	)
+
+	for (const [moduleName, content] of Object.entries(modules)) {
+		const moduleDir = path.join(srcDir, moduleName)
+		await fs.mkdir(moduleDir, { recursive: true })
+
+		if (typeof content === "string") {
+			const ext = moduleName === "agents" ? "test.yaml" : moduleName === "mcp" ? "test.json" : "test.md"
+			await fs.writeFile(path.join(moduleDir, ext), content, "utf-8")
+		} else if (typeof content === "object" && content !== null) {
+			for (const [entryName, entryContent] of Object.entries(content as Record<string, any>)) {
+				const entryPath = path.join(moduleDir, entryName)
+				if (typeof entryContent === "string") {
+					// Ensure parent directories exist
+					await fs.mkdir(path.dirname(entryPath), { recursive: true })
+					await fs.writeFile(entryPath, entryContent, "utf-8")
+				} else if (typeof entryContent === "object" && entryContent !== null) {
+					// Nested directory (e.g., skills/my-skill/skill.md)
+					await fs.mkdir(entryPath, { recursive: true })
+					for (const [subName, subContent] of Object.entries(entryContent as Record<string, string>)) {
+						await fs.writeFile(path.join(entryPath, subName), subContent, "utf-8")
+					}
+				}
+			}
+		}
+	}
+
+	zip.addLocalFolder(srcDir)
+	zip.writeZip(destPath)
+	await fs.rm(srcDir, { recursive: true, force: true })
+}
+
+describe("AgentInstaller edge cases", () => {
+	let tmpDir: string
+	let rooDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-edge-test-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("should install only existing modules when zip has partial modules", async () => {
+		// Create zip with only agents and commands (no skills, rules, mcp)
+		const zipPath = path.join(tmpDir, "partial.zip")
+		await createZipWithModules(zipPath, {
+			agents: "name: Test Agent\nslug: test-agent\n",
+			commands: { "test-cmd.md": "# Test Command\n" },
+		})
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		const manifest = await installer.install(zipPath, versionInfo, record)
+
+		expect(manifest.agents).toContain("test-agent")
+		expect(manifest.commands).toContain("test-cmd.md")
+		expect(manifest.skills).toEqual([])
+		expect(manifest.rules).toEqual([])
+		expect(manifest.mcp).toEqual([])
+	})
+
+	it("should replace ${skill_path} placeholders in skill .md files", async () => {
+		const zipPath = path.join(tmpDir, "skill-placeholder.zip")
+		await createZipWithModules(zipPath, {
+			agents: "name: Agent\nslug: agent-a\n",
+			skills: {
+				"my-skill": {
+					"skill.md": "Path is ${skill_path}/some/file.txt\nNo placeholder here.\n",
+				},
+			},
+		})
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		const manifest = await installer.install(zipPath, versionInfo, record)
+		expect(manifest.skills).toContain("my-skill")
+
+		// Verify the placeholder was replaced
+		const skillMd = fsSync.readFileSync(path.join(rooDir, "skills", "my-skill", "skill.md"), "utf-8")
+		expect(skillMd).not.toContain("${skill_path}")
+		expect(skillMd).toContain("/skills/my-skill/some/file.txt")
+		expect(skillMd).toContain("No placeholder here.")
+	})
+
+	it("should reject zip with path traversal entries", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const zipPath = path.join(tmpDir, "traversal.zip")
+		const zip = new AdmZip()
+
+		const srcDir = path.join(tmpDir, "traversal-src")
+		await fs.mkdir(srcDir, { recursive: true })
+		await fs.writeFile(
+			path.join(srcDir, "manifest.json"),
+			JSON.stringify({ version: "1.0.0", modules: ["agents"] }),
+			"utf-8",
+		)
+		await fs.mkdir(path.join(srcDir, "agents"), { recursive: true })
+		await fs.writeFile(path.join(srcDir, "agents", "evil.yaml"), "name: evil\nslug: evil\n", "utf-8")
+
+		zip.addLocalFolder(srcDir)
+		zip.writeZip(zipPath)
+		await fs.rm(srcDir, { recursive: true, force: true })
+
+		// Re-open the zip and inject a raw entry with path traversal
+		// adm-zip normalizes paths on addFile, so we need to manipulate the zip directly
+		const zip2 = new AdmZip(zipPath)
+		// Add entry with absolute path (also caught by the check: startsWith("/"))
+		zip2.addFile("/etc/evil.txt", Buffer.from("pwned"))
+		zip2.writeZip(zipPath)
+
+		// Verify the malicious entry exists
+		const verifyZip = new AdmZip(zipPath)
+		const hasTraversal = verifyZip.getEntries().some((e: any) => e.entryName.startsWith("/"))
+		if (!hasTraversal) {
+			// If adm-zip won't preserve the traversal entry, skip this test
+			console.warn("Skipping path traversal test: adm-zip normalizes entries on this platform")
+			return
+		}
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		await expect(installer.install(zipPath, versionInfo, record)).rejects.toThrow("path traversal")
+	})
+
+	it("should reject zip with manifest version mismatch", async () => {
+		const zipPath = path.join(tmpDir, "version-mismatch.zip")
+		const AdmZip = (await import("adm-zip")).default
+		const zip = new AdmZip()
+
+		const srcDir = path.join(tmpDir, "mismatch-src")
+		await fs.mkdir(srcDir, { recursive: true })
+		await fs.writeFile(
+			path.join(srcDir, "manifest.json"),
+			JSON.stringify({ version: "0.5.0", modules: [] }),
+			"utf-8",
+		)
+
+		zip.addLocalFolder(srcDir)
+		zip.writeZip(zipPath)
+		await fs.rm(srcDir, { recursive: true, force: true })
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		await expect(installer.install(zipPath, versionInfo, record)).rejects.toThrow("version mismatch")
+	})
+
+	it("should install agents and mcp to settingsDir when provided", async () => {
+		const zipPath = path.join(tmpDir, "settings-dir.zip")
+		await createZipWithModules(zipPath, {
+			agents: "name: SettingsDir Agent\nslug: settings-agent\n",
+			mcp: JSON.stringify({ name: "settings-server", url: "http://localhost" }),
+		})
+
+		const settingsDir = path.join(tmpDir, "settings")
+		await fs.mkdir(settingsDir, { recursive: true })
+		const installer = new AgentInstaller(tmpDir, rooDir, settingsDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		const manifest = await installer.install(zipPath, versionInfo, record)
+
+		// Verify agents were written to settingsDir, not rooDir
+		expect(fsSync.existsSync(path.join(settingsDir, "custom_modes.yaml"))).toBe(true)
+		expect(fsSync.existsSync(path.join(rooDir, "custom_modes.yaml"))).toBe(false)
+		expect(manifest.agents).toContain("settings-agent")
+
+		// Verify mcp was written to settingsDir, not rooDir
+		expect(fsSync.existsSync(path.join(settingsDir, "mcp_settings.json"))).toBe(true)
+		expect(fsSync.existsSync(path.join(rooDir, "mcp_settings.json"))).toBe(false)
+		expect(manifest.mcp).toContain("settings-server")
+	})
+
+	it("should use default rooDir ~/.roo when no rooDir argument is provided", async () => {
+		const mockHome = path.join(tmpDir, "mock-home")
+		await fs.mkdir(mockHome, { recursive: true })
+
+		// os.homedir() reads from USERPROFILE (Windows) or HOME (Linux/macOS)
+		const originalUserProfile = process.env.USERPROFILE
+		const originalHome = process.env.HOME
+		process.env.USERPROFILE = mockHome
+		process.env.HOME = mockHome
+
+		try {
+			// Re-import to pick up new homedir value
+			const { AgentInstaller: RI } = await import("../AgentInstaller")
+			const installer = new RI()
+			// Access private field via type assertion to verify default path
+			const actualRooDir = (installer as any).rooDir
+			expect(actualRooDir).toBe(path.join(mockHome, ".roo"))
+		} finally {
+			process.env.USERPROFILE = originalUserProfile
+			process.env.HOME = originalHome
+		}
+	})
+
+	it("should reject zip without manifest.json", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const zipPath = path.join(tmpDir, "no-manifest.zip")
+		const zip = new AdmZip()
+
+		const srcDir = path.join(tmpDir, "no-manifest-src")
+		await fs.mkdir(srcDir, { recursive: true })
+		await fs.mkdir(path.join(srcDir, "agents"), { recursive: true })
+		await fs.writeFile(path.join(srcDir, "agents", "test.yaml"), "name: test\nslug: test\n", "utf-8")
+
+		zip.addLocalFolder(srcDir)
+		zip.writeZip(zipPath)
+		await fs.rm(srcDir, { recursive: true, force: true })
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		await expect(installer.install(zipPath, versionInfo, record)).rejects.toThrow("manifest")
+	})
+
+	// Bug: corrupted local custom_modes.yaml should NOT be treated as FatalInstallerError.
+	// It is a local file issue, not a zip content issue. The installer should warn and
+	// fall back to an empty customModes array, then overwrite the corrupted file.
+	it("should warn and continue when local custom_modes.yaml is corrupted (not FatalError)", async () => {
+		const zipPath = path.join(tmpDir, "agents-test.zip")
+		await createZipWithModules(zipPath, {
+			agents: "name: Test Agent\nslug: test-agent\n",
+		})
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+
+		// Pre-create a corrupted custom_modes.yaml in rooDir
+		const customModesPath = path.join(rooDir, "custom_modes.yaml")
+		await fs.writeFile(customModesPath, "{ invalid yaml: [unclosed", "utf-8")
+
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		// Should NOT throw FatalInstallerError — should succeed by overwriting the corrupted file
+		const manifest = await installer.install(zipPath, versionInfo, record)
+		expect(manifest.agents).toContain("test-agent")
+	})
+
+	// Bug: corrupted local mcp_settings.json should NOT be treated as FatalInstallerError.
+	// It is a local file issue. The installer should warn and fall back to empty mcpServers.
+	it("should warn and continue when local mcp_settings.json is corrupted (not FatalError)", async () => {
+		const zipPath = path.join(tmpDir, "mcp-test.zip")
+		await createZipWithModules(zipPath, {
+			mcp: JSON.stringify({ name: "test-server", url: "http://localhost:3000" }),
+		})
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+
+		// Pre-create a corrupted mcp_settings.json in rooDir
+		const mcpSettingsPath = path.join(rooDir, "mcp_settings.json")
+		await fs.writeFile(mcpSettingsPath, "{ invalid json: [unclosed", "utf-8")
+
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		// Should NOT throw FatalInstallerError — should succeed by overwriting the corrupted file
+		const manifest = await installer.install(zipPath, versionInfo, record)
+		expect(manifest.mcp).toContain("test-server")
+	})
+
+	// Requirement 2: zip extra content is ignored and cleaned up with extractDir
+	it("should ignore extra content in zip (non-module directories) and clean up after install", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const zipPath = path.join(tmpDir, "extra-content.zip")
+		const zip = new AdmZip()
+
+		const srcDir = path.join(tmpDir, "extra-src")
+		await fs.mkdir(path.join(srcDir, "commands"), { recursive: true })
+		await fs.mkdir(path.join(srcDir, "extra-dir"), { recursive: true })
+		await fs.writeFile(
+			path.join(srcDir, "manifest.json"),
+			JSON.stringify({ version: "1.0.0", modules: ["commands"] }),
+			"utf-8",
+		)
+		await fs.writeFile(path.join(srcDir, "commands", "cmd.md"), "# Cmd\n", "utf-8")
+		// Extra content not in any known module
+		await fs.writeFile(path.join(srcDir, "extra-dir", "extra.txt"), "extra content", "utf-8")
+		await fs.writeFile(path.join(srcDir, "README.md"), "readme", "utf-8")
+
+		zip.addLocalFolder(srcDir)
+		zip.writeZip(zipPath)
+		await fs.rm(srcDir, { recursive: true, force: true })
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		const manifest = await installer.install(zipPath, versionInfo, record)
+
+		// Only known module content is installed
+		expect(manifest.commands).toContain("cmd.md")
+		expect(fsSync.existsSync(path.join(rooDir, "commands", "cmd.md"))).toBe(true)
+
+		// Extra content is NOT installed to rooDir
+		expect(fsSync.existsSync(path.join(rooDir, "extra-dir"))).toBe(false)
+		expect(fsSync.existsSync(path.join(rooDir, "README.md"))).toBe(false)
+
+		// extractDir is cleaned up after install (no residual temp files)
+		const extractDir = path.join(tmpDir, "remote-agent-package-1.0.0")
+		expect(fsSync.existsSync(extractDir)).toBe(false)
+	})
+
+	// Requirement 3: zip has no root directory (flat structure)
+	it("should install from zip with no root directory (flat zip structure)", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const zipPath = path.join(tmpDir, "flat-zip.zip")
+		const zip = new AdmZip()
+
+		// Build zip with flat structure: manifest.json and commands/ at root level
+		const srcDir = path.join(tmpDir, "flat-src")
+		await fs.mkdir(path.join(srcDir, "commands"), { recursive: true })
+		await fs.writeFile(
+			path.join(srcDir, "manifest.json"),
+			JSON.stringify({ version: "1.0.0", modules: ["commands"] }),
+			"utf-8",
+		)
+		await fs.writeFile(path.join(srcDir, "commands", "flat-cmd.md"), "# Flat Command\n", "utf-8")
+
+		zip.addLocalFolder(srcDir)
+		zip.writeZip(zipPath)
+		await fs.rm(srcDir, { recursive: true, force: true })
+
+		// Verify zip has flat structure (no root directory prefix)
+		const verifyZip = new AdmZip(zipPath)
+		const entries = verifyZip.getEntries().map((e: any) => e.entryName)
+		expect(entries.some((e: string) => e === "manifest.json" || e.startsWith("manifest.json"))).toBe(true)
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		const manifest = await installer.install(zipPath, versionInfo, record)
+		expect(manifest.commands).toContain("flat-cmd.md")
+		expect(fsSync.existsSync(path.join(rooDir, "commands", "flat-cmd.md"))).toBe(true)
+	})
+
+	// Requirement 5 (TDD): ${version} placeholder replacement in skill .md files
+	it("should replace ${version} placeholders in skill .md files", async () => {
+		const zipPath = path.join(tmpDir, "skill-version-placeholder.zip")
+		await createZipWithModules(
+			zipPath,
+			{
+				skills: {
+					"my-skill": {
+						"skill.md": "Version is ${version}\nPath is ${skill_path}/file.txt\n",
+						"other.md": "Also version ${version} here.\n",
+						"no-placeholder.md": "No placeholders here.\n",
+					},
+				},
+			},
+			"2.3.1",
+		)
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "2.3.1" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		const manifest = await installer.install(zipPath, versionInfo, record)
+		expect(manifest.skills).toContain("my-skill")
+
+		const skillMd = fsSync.readFileSync(path.join(rooDir, "skills", "my-skill", "skill.md"), "utf-8")
+		expect(skillMd).not.toContain("${version}")
+		expect(skillMd).toContain("Version is 2.3.1")
+		// ${skill_path} should also be replaced
+		expect(skillMd).not.toContain("${skill_path}")
+		expect(skillMd).toContain("/skills/my-skill/file.txt")
+
+		const otherMd = fsSync.readFileSync(path.join(rooDir, "skills", "my-skill", "other.md"), "utf-8")
+		expect(otherMd).not.toContain("${version}")
+		expect(otherMd).toContain("Also version 2.3.1 here.")
+
+		const noPlaceholderMd = fsSync.readFileSync(
+			path.join(rooDir, "skills", "my-skill", "no-placeholder.md"),
+			"utf-8",
+		)
+		expect(noPlaceholderMd).toBe("No placeholders here.\n")
+	})
+
+	// Requirement 5: ${version} placeholder is also replaced in agents/ YAML files
+	it("should replace ${version} placeholders in agents/ YAML files", async () => {
+		const zipPath = path.join(tmpDir, "agent-version-placeholder.zip")
+		await createZipWithModules(
+			zipPath,
+			{
+				agents: `name: My Agent v\${version}\nslug: my-agent\nroleDefinition: "Version \${version} agent"\n`,
+			},
+			"3.0.0",
+		)
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "3.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		const manifest = await installer.install(zipPath, versionInfo, record)
+		expect(manifest.agents).toContain("my-agent")
+
+		// Verify the agent was installed with version replaced
+		const customModesPath = path.join(rooDir, "custom_modes.yaml")
+		const content = fsSync.readFileSync(customModesPath, "utf-8")
+		expect(content).not.toContain("${version}")
+		expect(content).toContain("3.0.0")
+	})
+
+	// Requirement 5: ${version} placeholder is also replaced in commands/ .md files
+	it("should replace ${version} placeholders in commands/ .md files", async () => {
+		const zipPath = path.join(tmpDir, "command-version-placeholder.zip")
+		await createZipWithModules(
+			zipPath,
+			{
+				commands: {
+					"my-command.md": "# My Command v${version}\n\nThis command is for version ${version}.\n",
+				},
+			},
+			"4.2.0",
+		)
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "4.2.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		const manifest = await installer.install(zipPath, versionInfo, record)
+		expect(manifest.commands).toContain("my-command.md")
+
+		const cmdMd = fsSync.readFileSync(path.join(rooDir, "commands", "my-command.md"), "utf-8")
+		expect(cmdMd).not.toContain("${version}")
+		expect(cmdMd).toContain("My Command v4.2.0")
+		expect(cmdMd).toContain("version 4.2.0")
+	})
+
+	// Requirement 5: ${version} placeholder is NOT replaced in non-.md files in skills
+	it("should NOT replace ${version} in non-.md files in skills", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const zipPath = path.join(tmpDir, "skill-version-non-md.zip")
+		const zip = new AdmZip()
+
+		const srcDir = path.join(tmpDir, "skill-non-md-src")
+		await fs.mkdir(path.join(srcDir, "skills", "my-skill"), { recursive: true })
+		await fs.writeFile(
+			path.join(srcDir, "manifest.json"),
+			JSON.stringify({ version: "1.5.0", modules: ["skills"] }),
+			"utf-8",
+		)
+		await fs.writeFile(path.join(srcDir, "skills", "my-skill", "skill.md"), "Version ${version}\n", "utf-8")
+		await fs.writeFile(path.join(srcDir, "skills", "my-skill", "config.json"), '{"v":"${version}"}', "utf-8")
+		await fs.writeFile(path.join(srcDir, "skills", "my-skill", "script.sh"), "echo ${version}", "utf-8")
+
+		zip.addLocalFolder(srcDir)
+		zip.writeZip(zipPath)
+		await fs.rm(srcDir, { recursive: true, force: true })
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.5.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		await installer.install(zipPath, versionInfo, record)
+
+		// .md file: ${version} replaced
+		const skillMd = fsSync.readFileSync(path.join(rooDir, "skills", "my-skill", "skill.md"), "utf-8")
+		expect(skillMd).toContain("Version 1.5.0")
+
+		// non-.md files: ${version} NOT replaced (unchanged)
+		const configJson = fsSync.readFileSync(path.join(rooDir, "skills", "my-skill", "config.json"), "utf-8")
+		expect(configJson).toBe('{"v":"${version}"}')
+
+		const scriptSh = fsSync.readFileSync(path.join(rooDir, "skills", "my-skill", "script.sh"), "utf-8")
+		expect(scriptSh).toBe("echo ${version}")
+	})
+})
+
+// ─── Fix [M-3]: uninstallMcp should not throw when mcp_settings.json is corrupted ───
+describe("AgentInstaller uninstall edge cases", () => {
+	let tmpDir: string
+	let rooDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-uninstall-edge-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("[M-3] should not throw when mcp_settings.json is corrupted during uninstall", async () => {
+		// Write a corrupted mcp_settings.json
+		const mcpSettingsPath = path.join(rooDir, "mcp_settings.json")
+		await fs.writeFile(mcpSettingsPath, "{ invalid json !!!", "utf-8")
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: {
+				agents: [],
+				commands: [],
+				skills: [],
+				rules: [],
+				mcp: ["my-server"],
+			},
+		}
+
+		// Should NOT throw — corrupted mcp_settings.json during uninstall must be handled gracefully
+		await expect(installer.uninstall(record)).resolves.not.toThrow()
+	})
+
+	it("[M-3] should not throw when mcp_settings.json is corrupted and uninstall completes other modules", async () => {
+		// Create a command file to uninstall
+		const commandsDir = path.join(rooDir, "commands")
+		await fs.mkdir(commandsDir, { recursive: true })
+		await fs.writeFile(path.join(commandsDir, "test.md"), "# test", "utf-8")
+
+		// Write a corrupted mcp_settings.json
+		const mcpSettingsPath = path.join(rooDir, "mcp_settings.json")
+		await fs.writeFile(mcpSettingsPath, "CORRUPTED", "utf-8")
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: {
+				agents: [],
+				commands: ["test.md"],
+				skills: [],
+				rules: [],
+				mcp: ["my-server"],
+			},
+		}
+
+		// Should NOT throw — corrupted mcp_settings.json must not block other module uninstalls
+		await expect(installer.uninstall(record)).resolves.not.toThrow()
+
+		// The command file should still be uninstalled
+		const cmdExists = await fs
+			.access(path.join(commandsDir, "test.md"))
+			.then(() => true)
+			.catch(() => false)
+		expect(cmdExists).toBe(false)
+	})
+})
+
+// ─── Fix [m-2]: extractZip path traversal detection ───
+describe("AgentInstaller extractZip path traversal (enhanced)", () => {
+	let tmpDir: string
+	let rooDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-traversal-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("[m-2] should throw FatalInstallerError when zip entry uses forward-slash path traversal (../)", async () => {
+		// adm-zip's addFile() API sanitizes paths, so we must directly set entryName
+		// to simulate a maliciously crafted zip file with a real path traversal entry.
+		const AdmZip = (await import("adm-zip")).default
+		const zip = new AdmZip()
+		zip.addFile("manifest.json", Buffer.from(JSON.stringify({ version: "1.0.0", modules: [] })))
+		// Add a placeholder entry, then overwrite entryName to inject traversal
+		zip.addFile("placeholder.txt", Buffer.from("evil content"))
+		const entries = zip.getEntries()
+		const evilEntry = entries.find((e) => e.entryName === "placeholder.txt")!
+		evilEntry.entryName = "../evil.txt"
+		const zipPath = path.join(tmpDir, "traversal-forward.zip")
+		zip.writeZip(zipPath)
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo = { version: "1.0.0", downloadUrl: "http://example.com/test.zip" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		await expect(installer.install(zipPath, versionInfo, record)).rejects.toThrow(FatalInstallerError)
+	})
+
+	it("[m-2] should throw FatalInstallerError when zip entry uses backslash path traversal (..\\)", async () => {
+		// adm-zip's addFile() API sanitizes paths, so we must directly set entryName
+		// to simulate a maliciously crafted zip file with a Windows-style backslash traversal.
+		const AdmZip = (await import("adm-zip")).default
+		const zip = new AdmZip()
+		zip.addFile("manifest.json", Buffer.from(JSON.stringify({ version: "1.0.0", modules: [] })))
+		zip.addFile("placeholder.txt", Buffer.from("evil content"))
+		const entries = zip.getEntries()
+		const evilEntry = entries.find((e) => e.entryName === "placeholder.txt")!
+		// Use backslash-based traversal — our fix normalizes this before checking
+		evilEntry.entryName = "..\\evil.txt"
+		const zipPath = path.join(tmpDir, "traversal-backslash.zip")
+		zip.writeZip(zipPath)
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo = { version: "1.0.0", downloadUrl: "http://example.com/test.zip" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		await expect(installer.install(zipPath, versionInfo, record)).rejects.toThrow(FatalInstallerError)
+	})
+})
+
+// ─── Fix [m-2b]: extractZip should NOT reject legitimate filenames containing ".." ───
+describe("AgentInstaller extractZip path traversal (false-positive prevention)", () => {
+	let tmpDir: string
+	let rooDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-traversal-fp-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("[m-2b] should NOT reject a zip entry with '..hidden' filename (not a traversal)", async () => {
+		// A filename like "..hidden" contains ".." but is NOT a path traversal.
+		// The fix must use path-segment matching (segment === "..") not includes("..").
+		const AdmZip = (await import("adm-zip")).default
+		const zip = new AdmZip()
+		zip.addFile("manifest.json", Buffer.from(JSON.stringify({ version: "1.0.0", modules: [] })))
+		// "..hidden" is a valid filename on Unix/macOS (hidden file starting with ..)
+		// adm-zip may sanitize this, so we directly set entryName
+		zip.addFile("placeholder.txt", Buffer.from("safe content"))
+		const entries = zip.getEntries()
+		const entry = entries.find((e) => e.entryName === "placeholder.txt")!
+		entry.entryName = "..hidden"
+		const zipPath = path.join(tmpDir, "dotdot-filename.zip")
+		zip.writeZip(zipPath)
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0", downloadUrl: "http://example.com/test.zip" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		// Should NOT throw FatalInstallerError for "..hidden" — it's a valid filename, not a traversal
+		// (The install may fail for other reasons like missing manifest content, but not pathTraversal)
+		try {
+			await installer.install(zipPath, versionInfo, record)
+		} catch (err: any) {
+			// If it throws, it must NOT be a pathTraversal error
+			expect(err?.code).not.toBe("pathTraversal")
+		}
+	})
+
+	it("[m-2b] should NOT reject a zip entry with 'file..name' filename (not a traversal)", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const zip = new AdmZip()
+		zip.addFile("manifest.json", Buffer.from(JSON.stringify({ version: "1.0.0", modules: [] })))
+		zip.addFile("placeholder.txt", Buffer.from("safe content"))
+		const entries = zip.getEntries()
+		const entry = entries.find((e) => e.entryName === "placeholder.txt")!
+		entry.entryName = "file..name.txt"
+		const zipPath = path.join(tmpDir, "dotdot-middle.zip")
+		zip.writeZip(zipPath)
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0", downloadUrl: "http://example.com/test.zip" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		try {
+			await installer.install(zipPath, versionInfo, record)
+		} catch (err: any) {
+			expect(err?.code).not.toBe("pathTraversal")
+		}
+	})
+})
+
+// ─── Fix [m-4]: atomicReplaceDirectory should restore backup on rename failure (non-Windows) ───
+// Note: We cannot mock ESM fs/promises.rename directly (ESM namespace is not configurable).
+// Instead, we test the backup-restoration behavior by verifying the function's contract:
+// when rename(src, dest) fails, the original dest content must be preserved.
+// We simulate this by making src a non-existent path (rename will fail with ENOENT).
+describe("atomicReplaceDirectory backup restoration on failure", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-atomic-restore-${Date.now()}`)
+		await fs.mkdir(tmpDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("[m-4] should restore dest from backup when rename(src, dest) fails (src does not exist)", async () => {
+		// Scenario: dest exists, src does NOT exist.
+		// atomicReplaceDirectory will:
+		//   1. rename(dest, backup) → success (hasBackup = true)
+		//   2. rename(src, dest) → fails with ENOENT (src missing)
+		// Expected: dest is restored from backup (original content preserved)
+		const { atomicReplaceDirectory } = await import("../AgentInstaller")
+		const src = path.join(tmpDir, "nonexistent-src-dir") // does NOT exist
+		const dest = path.join(tmpDir, "dest-dir")
+
+		// Create dest with original content
+		await fs.mkdir(dest, { recursive: true })
+		await fs.writeFile(path.join(dest, "original.txt"), "original content", "utf-8")
+
+		// atomicReplaceDirectory should throw because src doesn't exist
+		await expect(atomicReplaceDirectory(src, dest)).rejects.toThrow()
+
+		// After failure, dest should be restored (original content preserved)
+		const destExists = await fs
+			.access(dest)
+			.then(() => true)
+			.catch(() => false)
+		expect(destExists).toBe(true)
+		const originalContent = await fs.readFile(path.join(dest, "original.txt"), "utf-8").catch(() => null)
+		expect(originalContent).toBe("original content")
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/AgentInstaller.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/AgentInstaller.test.ts
@@ -1,0 +1,444 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as os from "os"
+import { AgentInstaller, atomicCopyFile, atomicReplaceDirectory } from "../AgentInstaller"
+import type { LocalInstallRecord, ResourcePackageVersion } from "../types"
+import { safeWriteJson } from "../../../../utils/safeWriteJson"
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}))
+
+vi.mock("../../../../utils/safeWriteJson", () => ({
+	safeWriteJson: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe("AgentInstaller atomic operations", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-atomic-test-${Date.now()}`)
+		await fs.mkdir(tmpDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("atomicCopyFile copies file atomically", async () => {
+		const src = path.join(tmpDir, "src.txt")
+		const dest = path.join(tmpDir, "dest.txt")
+		await fs.writeFile(src, "hello", "utf-8")
+		await atomicCopyFile(src, dest)
+		const content = await fs.readFile(dest, "utf-8")
+		expect(content).toBe("hello")
+	})
+
+	it("atomicReplaceDirectory replaces directory atomically", async () => {
+		const src = path.join(tmpDir, "src-dir")
+		const dest = path.join(tmpDir, "dest-dir")
+		await fs.mkdir(src, { recursive: true })
+		await fs.writeFile(path.join(src, "file.txt"), "new", "utf-8")
+		await fs.mkdir(dest, { recursive: true })
+		await fs.writeFile(path.join(dest, "file.txt"), "old", "utf-8")
+		await atomicReplaceDirectory(src, dest)
+		const content = await fs.readFile(path.join(dest, "file.txt"), "utf-8")
+		expect(content).toBe("new")
+	})
+})
+
+describe("AgentInstaller install/uninstall", () => {
+	let tmpDir: string
+	let rooDir: string
+	let installer: AgentInstaller
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-test-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+		installer = new AgentInstaller(tmpDir, rooDir)
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("should cleanup temporary files", async () => {
+		const zipPath = path.join(tmpDir, "test.zip")
+		const extractDir = path.join(tmpDir, "extract")
+		await fs.writeFile(zipPath, "data", "utf-8")
+		await fs.mkdir(extractDir, { recursive: true })
+		await installer.cleanup(zipPath, extractDir)
+		const zipExists = await fs
+			.access(zipPath)
+			.then(() => true)
+			.catch(() => false)
+		const dirExists = await fs
+			.access(extractDir)
+			.then(() => true)
+			.catch(() => false)
+		expect(zipExists).toBe(false)
+		expect(dirExists).toBe(false)
+	})
+
+	it("should uninstall without manifest gracefully", async () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		await expect(installer.uninstall(record)).resolves.not.toThrow()
+	})
+
+	// Bug4 regression: when install() fails internally, it should NOT delete the zip file.
+	// The zip file must be preserved so the outer runInstallWithRetries can reuse it on retry
+	// without re-downloading. Only the extractDir should be cleaned up internally.
+	it("should preserve zip file when install fails internally", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		}
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		// Create a zip that will fail manifest validation (missing manifest.json)
+		const zipPath = path.join(tmpDir, "remote-agent-package-1.0.0.zip")
+		const zip = new AdmZip()
+		zip.addFile("dummy.txt", Buffer.from("dummy"))
+		zip.writeZip(zipPath)
+
+		// install() should throw because manifest.json is missing
+		await expect(installer.install(zipPath, versionInfo, record)).rejects.toThrow()
+
+		// The zip file must still exist after the internal failure
+		const zipExists = await fs
+			.access(zipPath)
+			.then(() => true)
+			.catch(() => false)
+		expect(zipExists).toBe(true)
+	})
+
+	// FR-013: install() must call uninstall() before installing new modules
+	// Verifies that old version content is cleaned up before new content is written.
+	it("should call uninstall before installing new modules (FR-013)", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const versionInfo: ResourcePackageVersion = {
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		}
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		// Create a valid zip with manifest.json
+		const zipPath = path.join(tmpDir, "remote-agent-package-2.0.0.zip")
+		const zip = new AdmZip()
+		zip.addFile("manifest.json", Buffer.from(JSON.stringify({ version: "2.0.0", modules: [] })))
+		zip.writeZip(zipPath)
+
+		// Spy on uninstall to track call order
+		const callOrder: string[] = []
+		const originalUninstall = installer.uninstall.bind(installer)
+		vi.spyOn(installer, "uninstall").mockImplementation(async (r) => {
+			callOrder.push("uninstall")
+			return originalUninstall(r)
+		})
+
+		// We need to intercept installModule calls — but since no modules are in zip,
+		// we just verify uninstall was called before install completes
+		await installer.install(zipPath, versionInfo, record)
+
+		expect(callOrder).toContain("uninstall")
+		// uninstall must have been called (before any module installation)
+		expect(installer.uninstall).toHaveBeenCalledWith(record)
+	})
+
+	// FR-013: uninstall failure should not block install (warning logged, install continues)
+	it("should continue install even when uninstall fails (FR-013 non-blocking)", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const versionInfo: ResourcePackageVersion = {
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		}
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			// Manifest with a non-existent agent to trigger uninstall attempt
+			manifest: { agents: ["ghost-agent"], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		// Create a valid zip with manifest.json
+		const zipPath = path.join(tmpDir, "remote-agent-package-2.0.0.zip")
+		const zip = new AdmZip()
+		zip.addFile("manifest.json", Buffer.from(JSON.stringify({ version: "2.0.0", modules: [] })))
+		zip.writeZip(zipPath)
+
+		// Even if uninstall encounters issues (e.g., files already gone), install should succeed
+		await expect(installer.install(zipPath, versionInfo, record)).resolves.not.toThrow()
+	})
+
+	// BUG-5 regression: uninstall() must not throw even when verifyUninstalled() throws
+	// unexpectedly. The verification step is non-critical and should be wrapped in try-catch.
+	it("should not throw when verifyUninstalled throws unexpectedly", async () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: { agents: ["test-agent"], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		// Spy on the private verifyUninstalled method to make it throw
+		const verifyUninstalledSpy = vi
+			.spyOn(installer as any, "verifyUninstalled")
+			.mockRejectedValue(new Error("Unexpected filesystem error"))
+
+		try {
+			// uninstall() should NOT propagate the error from verifyUninstalled
+			await expect(installer.uninstall(record)).resolves.not.toThrow()
+		} finally {
+			verifyUninstalledSpy.mockRestore()
+		}
+	})
+})
+
+describe("AgentInstaller FR-013 uninstall-non-blocking in install()", () => {
+	let tmpDir: string
+	let rooDir: string
+	let installer: AgentInstaller
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-fr013-test-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+		installer = new AgentInstaller(tmpDir, rooDir)
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	// FR-013 regression: install() must NOT propagate exceptions thrown by uninstall().
+	// Even if uninstall() throws unexpectedly (e.g. due to a bug in its internals),
+	// the install flow must continue and succeed.
+	it("should continue install even when uninstall() throws unexpectedly (FR-013 non-blocking)", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const versionInfo: ResourcePackageVersion = {
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		}
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+
+		// Create a valid zip with manifest.json only (no modules)
+		const zipPath = path.join(tmpDir, "remote-agent-package-2.0.0.zip")
+		const zip = new AdmZip()
+		zip.addFile("manifest.json", Buffer.from(JSON.stringify({ version: "2.0.0", modules: [] })))
+		zip.writeZip(zipPath)
+
+		// Force uninstall() to throw an unexpected error (simulates a bug in uninstall internals)
+		const uninstallSpy = vi.spyOn(installer, "uninstall").mockRejectedValue(new Error("Unexpected uninstall error"))
+
+		try {
+			// install() must NOT throw — uninstall failure is non-blocking per FR-013
+			await expect(installer.install(zipPath, versionInfo, record)).resolves.not.toThrow()
+		} finally {
+			uninstallSpy.mockRestore()
+		}
+	})
+})
+
+// ─── Bug fix regression tests ────────────────────────────────────────────────
+// ─── Bug fix regression tests ────────────────────────────────────────────────
+
+describe("atomicReplaceDirectory — backup restore on cp failure (Windows path)", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-atomic-win-test-${Date.now()}`)
+		await fs.mkdir(tmpDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	// Bug: when fs.cp fails on the Windows fallback path, the original dest directory
+	// (which was renamed to backup) must be restored so no data is lost.
+	// We test this by calling the exported atomicReplaceDirectory with a src that
+	// cannot be renamed (simulated by making src read-only on non-Windows, or by
+	// testing the backup-restore contract via a wrapper that exposes the failure path).
+	//
+	// Since we cannot mock ESM fs module, we test the observable contract:
+	// if atomicReplaceDirectory throws, dest must still exist with original content.
+	it("should preserve dest content when rename fails and no fallback succeeds", async () => {
+		const src = path.join(tmpDir, "src-dir")
+		const dest = path.join(tmpDir, "dest-dir")
+
+		// Create src and dest directories
+		await fs.mkdir(src, { recursive: true })
+		await fs.writeFile(path.join(src, "new.txt"), "new content", "utf-8")
+		await fs.mkdir(dest, { recursive: true })
+		await fs.writeFile(path.join(dest, "original.txt"), "original content", "utf-8")
+
+		// Normal operation: atomicReplaceDirectory should succeed and replace dest with src
+		await atomicReplaceDirectory(src, dest)
+
+		// After success, dest should have new content
+		const newContent = await fs.readFile(path.join(dest, "new.txt"), "utf-8")
+		expect(newContent).toBe("new content")
+
+		// Original file should be gone (replaced)
+		const originalExists = await fs
+			.access(path.join(dest, "original.txt"))
+			.then(() => true)
+			.catch(() => false)
+		expect(originalExists).toBe(false)
+	})
+
+	// Verify that when src does not exist, atomicReplaceDirectory throws and dest is preserved.
+	// This tests the backup-restore path: if rename(src→dest) fails after backup was created,
+	// the backup must be restored to dest.
+	it("should restore dest when src rename fails (dest preserved after error)", async () => {
+		const src = path.join(tmpDir, "nonexistent-src-dir") // src does not exist
+		const dest = path.join(tmpDir, "dest-dir")
+
+		// Create dest with original content
+		await fs.mkdir(dest, { recursive: true })
+		await fs.writeFile(path.join(dest, "original.txt"), "original content", "utf-8")
+
+		// atomicReplaceDirectory should throw because src doesn't exist
+		await expect(atomicReplaceDirectory(src, dest)).rejects.toThrow()
+
+		// After failure, dest must still exist with original content (backup was restored)
+		const originalContent = await fs.readFile(path.join(dest, "original.txt"), "utf-8")
+		expect(originalContent).toBe("original content")
+	})
+})
+describe("AgentInstaller.uninstallMcp — corrupted JSON handling", () => {
+	let tmpDir: string
+	let rooDir: string
+	let installer: AgentInstaller
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-mcp-test-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+		installer = new AgentInstaller(tmpDir, rooDir)
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	// Bug: uninstallMcp uses JSON.parse without try/catch. If mcp_settings.json is
+	// corrupted, it throws an uncaught exception that propagates through uninstall(),
+	// breaking the entire uninstall flow.
+	it("should not throw when mcp_settings.json is corrupted during uninstall", async () => {
+		// Write a corrupted mcp_settings.json
+		const mcpSettingsPath = path.join(rooDir, "mcp_settings.json")
+		await fs.writeFile(mcpSettingsPath, "{ invalid json !!!", "utf-8")
+
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: ["my-server"] },
+		}
+
+		// uninstall() should NOT throw even when mcp_settings.json is corrupted
+		await expect(installer.uninstall(record)).resolves.not.toThrow()
+	})
+
+	// Regression: when mcp_settings.json is corrupted, uninstallMcp should log a warning
+	// and skip the write (safeWriteJson must NOT be called with corrupted data).
+	// Previously, JSON.parse threw and the error propagated silently through uninstall()'s
+	// per-module catch block, leaving the corrupted file untouched. Now the error is caught
+	// inside uninstallMcp itself, logged, and the function returns early.
+	it("should not call safeWriteJson when mcp_settings.json is corrupted", async () => {
+		const safeWriteJsonMock = vi.mocked(safeWriteJson)
+		safeWriteJsonMock.mockClear()
+
+		const mcpSettingsPath = path.join(rooDir, "mcp_settings.json")
+		await fs.writeFile(mcpSettingsPath, "{ invalid json !!!", "utf-8")
+
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: ["my-server"] },
+		}
+
+		await installer.uninstall(record)
+
+		// safeWriteJson must NOT be called when the source JSON is corrupted —
+		// writing corrupted data back would destroy the file.
+		expect(safeWriteJsonMock).not.toHaveBeenCalledWith(mcpSettingsPath, expect.anything())
+	})
+
+	// Regression: when mcp_settings.json is valid, uninstallMcp should successfully
+	// remove the specified server and call safeWriteJson with the updated data.
+	it("should successfully remove mcp server when mcp_settings.json is valid", async () => {
+		const safeWriteJsonMock = vi.mocked(safeWriteJson)
+		safeWriteJsonMock.mockClear()
+
+		const mcpSettingsPath = path.join(rooDir, "mcp_settings.json")
+		const initialSettings = {
+			mcpServers: {
+				"my-server": { command: "node", args: ["server.js"] },
+				"other-server": { command: "python", args: ["server.py"] },
+			},
+		}
+		await fs.writeFile(mcpSettingsPath, JSON.stringify(initialSettings), "utf-8")
+
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: ["my-server"] },
+		}
+
+		await installer.uninstall(record)
+
+		// safeWriteJson should be called with the updated settings (my-server removed)
+		expect(safeWriteJsonMock).toHaveBeenCalledWith(
+			mcpSettingsPath,
+			expect.objectContaining({
+				mcpServers: expect.not.objectContaining({ "my-server": expect.anything() }),
+			}),
+		)
+		// other-server should still be present
+		const callArgs = safeWriteJsonMock.mock.calls.find((args) => args[0] === mcpSettingsPath)
+		expect(callArgs?.[1]?.mcpServers?.["other-server"]).toBeDefined()
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/AgentInstaller.verify.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/AgentInstaller.verify.test.ts
@@ -1,0 +1,170 @@
+/**
+ * AgentInstaller verification tests.
+ * Covers: install verification, uninstall verification, warning detection.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import * as path from "path"
+import * as os from "os"
+import { AgentInstaller } from "../AgentInstaller"
+import type { InstalledManifest, LocalInstallRecord, ResourcePackageVersion } from "../types"
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	}),
+}))
+
+vi.mock("../../../utils/safeWriteJson", () => ({
+	safeWriteJson: vi.fn().mockResolvedValue(undefined),
+}))
+
+async function createZipWithModules(destPath: string, modules: Record<string, any>): Promise<void> {
+	const AdmZip = (await import("adm-zip")).default
+	const zip = new AdmZip()
+
+	const srcDir = path.join(path.dirname(destPath), "zip-src-" + Date.now())
+	await fs.mkdir(srcDir, { recursive: true })
+
+	const manifestModules = Object.keys(modules)
+	await fs.writeFile(
+		path.join(srcDir, "manifest.json"),
+		JSON.stringify({ version: "1.0.0", modules: manifestModules }),
+		"utf-8",
+	)
+
+	for (const [moduleName, content] of Object.entries(modules)) {
+		const moduleDir = path.join(srcDir, moduleName)
+		await fs.mkdir(moduleDir, { recursive: true })
+
+		if (typeof content === "string") {
+			const ext = moduleName === "agents" ? "test.yaml" : moduleName === "mcp" ? "test.json" : "test.md"
+			await fs.writeFile(path.join(moduleDir, ext), content, "utf-8")
+		} else if (typeof content === "object" && content !== null) {
+			for (const [entryName, entryContent] of Object.entries(content as Record<string, any>)) {
+				const entryPath = path.join(moduleDir, entryName)
+				if (typeof entryContent === "string") {
+					await fs.mkdir(path.dirname(entryPath), { recursive: true })
+					await fs.writeFile(entryPath, entryContent, "utf-8")
+				} else if (typeof entryContent === "object" && entryContent !== null) {
+					await fs.mkdir(entryPath, { recursive: true })
+					for (const [subName, subContent] of Object.entries(entryContent as Record<string, string>)) {
+						await fs.writeFile(path.join(entryPath, subName), subContent, "utf-8")
+					}
+				}
+			}
+		}
+	}
+
+	zip.addLocalFolder(srcDir)
+	zip.writeZip(destPath)
+	await fs.rm(srcDir, { recursive: true, force: true })
+}
+
+describe("AgentInstaller verification", () => {
+	let tmpDir: string
+	let rooDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `ri-verify-test-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("should return empty warnings after successful install verification", async () => {
+		const zipPath = path.join(tmpDir, "verify-install.zip")
+		await createZipWithModules(zipPath, {
+			agents: "name: Verify Agent\nslug: verify-agent\n",
+			commands: "# Verify Command\n",
+		})
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		const installedManifest = await installer.install(zipPath, versionInfo, record)
+		const warnings = await (installer as any).verifyInstalled(installedManifest)
+		expect(warnings).toEqual([])
+	})
+
+	it("should warn when installed item is missing during verification", async () => {
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const manifest: InstalledManifest = {
+			agents: ["missing-agent"],
+			commands: ["missing.md"],
+			skills: ["missing-skill"],
+			rules: ["missing-rule"],
+			mcp: ["missing-server"],
+		}
+		const warnings = await (installer as any).verifyInstalled(manifest)
+		expect(warnings.length).toBeGreaterThan(0)
+		expect(warnings).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("custom_modes.yaml missing"),
+				expect.stringContaining("mcp_settings.json missing"),
+				expect.stringContaining('command "missing.md" missing'),
+				expect.stringContaining('skill "missing-skill" missing'),
+				expect.stringContaining('rule "missing-rule" missing'),
+			]),
+		)
+	})
+
+	it("should warn when uninstalled item is still present during verification", async () => {
+		const zipPath = path.join(tmpDir, "verify-uninstall.zip")
+		await createZipWithModules(zipPath, {
+			agents: "name: Uninstall Agent\nslug: uninstall-agent\n",
+			commands: "# Uninstall Command\n",
+		})
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		const installedManifest = await installer.install(zipPath, versionInfo, record)
+		const warnings = await (installer as any).verifyUninstalled(installedManifest)
+		expect(warnings.length).toBeGreaterThan(0)
+		expect(warnings).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining('agent "uninstall-agent" still present'),
+				expect.stringContaining('command "test.md" still present'),
+			]),
+		)
+	})
+
+	it("should return empty warnings after successful uninstall verification", async () => {
+		const zipPath = path.join(tmpDir, "verify-uninstall-ok.zip")
+		await createZipWithModules(zipPath, {
+			agents: "name: Ok Agent\nslug: ok-agent\n",
+		})
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		const installedManifest = await installer.install(zipPath, versionInfo, record)
+		await installer.uninstall({ ...record, manifest: installedManifest })
+		const warnings = await (installer as any).verifyUninstalled(installedManifest)
+		expect(warnings).toEqual([])
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/InstallRecordManager.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/InstallRecordManager.test.ts
@@ -13,6 +13,17 @@ vi.mock("../../../utils/logger", () => ({
 	}),
 }))
 
+// Mock getCheckIntervalMs to always return 12h regardless of environment variables.
+// Without this, COSTRICT_AGENT_CHECK_INTERVAL_MINUTES in the environment can cause
+// shouldCheck boundary tests to fail (e.g. 11h59m would exceed a 1-minute interval).
+vi.mock("../utils", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../utils")>()
+	return {
+		...actual,
+		getCheckIntervalMs: () => 12 * 60 * 60 * 1000,
+	}
+})
+
 describe("InstallRecordManager", () => {
 	let tmpDir: string
 	let manager: InstallRecordManager

--- a/src/core/costrict/remote-agent-installer/__tests__/InstallRecordManager.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/InstallRecordManager.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as os from "os"
+import { InstallRecordManager } from "../InstallRecordManager"
+import type { LocalInstallRecord } from "../types"
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}))
+
+describe("InstallRecordManager", () => {
+	let tmpDir: string
+	let manager: InstallRecordManager
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `rr-test-${Date.now()}`)
+		await fs.mkdir(tmpDir, { recursive: true })
+		manager = new InstallRecordManager(path.join(tmpDir, "record.json"))
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("should return default record when file does not exist", async () => {
+		const record = await manager.read()
+		expect(record.installedVersion).toBe("0.0.0")
+		expect(record.installState).toBe("none")
+		expect(record.schemaVersion).toBe(1)
+		expect(record.lastCheckedAt).toBe(0)
+		expect(record.manifest.agents).toEqual([])
+	})
+
+	it("should read existing record", async () => {
+		const existing: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.2.3",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: { agents: ["a"], commands: ["b"], skills: ["c"], rules: ["d"], mcp: ["e"] },
+		}
+		await fs.writeFile(path.join(tmpDir, "record.json"), JSON.stringify(existing), "utf-8")
+		const record = await manager.read()
+		expect(record.installedVersion).toBe("1.2.3")
+		expect(record.installState).toBe("installed")
+	})
+
+	it("should reset to default when schema version mismatch", async () => {
+		const bad = {
+			schemaVersion: 0,
+			installedVersion: "1.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: {},
+		}
+		await fs.writeFile(path.join(tmpDir, "record.json"), JSON.stringify(bad), "utf-8")
+		const record = await manager.read()
+		expect(record.installedVersion).toBe("0.0.0")
+	})
+
+	it("should reset to default on invalid JSON", async () => {
+		await fs.writeFile(path.join(tmpDir, "record.json"), "not json", "utf-8")
+		const record = await manager.read()
+		expect(record.installedVersion).toBe("0.0.0")
+	})
+
+	it("should write and read back record", async () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "2.0.0",
+			lastCheckedAt: 12345,
+			installState: "installed",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		await manager.write(record)
+		const readBack = await manager.read()
+		expect(readBack.installedVersion).toBe("2.0.0")
+		expect(readBack.lastCheckedAt).toBe(12345)
+	})
+
+	it("shouldCheck returns true when lastCheckedAt is 0", () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		expect(manager.shouldCheck(record)).toBe(true)
+	})
+
+	it("shouldCheck returns false within 12 hours (1 second ago)", () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: Date.now() - 1000,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		expect(manager.shouldCheck(record)).toBe(false)
+	})
+
+	// Critical boundary test: 11h59m should still be within cooldown (< 12h)
+	it("shouldCheck returns false at 11h59m (just under 12h cooldown)", () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: Date.now() - (12 * 60 * 60 * 1000 - 60 * 1000), // 11h59m ago
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		expect(manager.shouldCheck(record)).toBe(false)
+	})
+
+	// Critical boundary test: exactly 12h should trigger a check (>= 12h)
+	it("shouldCheck returns true at exactly 12h cooldown boundary", () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: Date.now() - 12 * 60 * 60 * 1000,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		expect(manager.shouldCheck(record)).toBe(true)
+	})
+
+	// Critical boundary test: 13h (between 12h and 24h) must return true.
+	// This test would FAIL if cooldown were 24h, catching any regression to 24h.
+	it("shouldCheck returns true at 13h (between 12h and 24h — catches 24h regression)", () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: Date.now() - 13 * 60 * 60 * 1000,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		expect(manager.shouldCheck(record)).toBe(true)
+	})
+
+	it("shouldCheck returns true after 25 hours", () => {
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "0.0.0",
+			lastCheckedAt: Date.now() - 25 * 60 * 60 * 1000,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		}
+		expect(manager.shouldCheck(record)).toBe(true)
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.flow.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.flow.test.ts
@@ -1,0 +1,846 @@
+/**
+ * RemoteAgentInstaller orchestration flow tests.
+ * Covers: version comparison, retry mechanism, manual trigger, no-update scenarios.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as os from "os"
+
+vi.mock("vscode", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("vscode")>()
+	return {
+		...actual,
+		window: {
+			...actual.window,
+			createOutputChannel: vi.fn(() => ({ appendLine: vi.fn(), dispose: vi.fn() })),
+			createStatusBarItem: vi.fn(() => ({ text: "", show: vi.fn(), hide: vi.fn(), dispose: vi.fn() })),
+			showInformationMessage: vi.fn(),
+			showWarningMessage: vi.fn(),
+			showErrorMessage: vi.fn(),
+		},
+		extensions: {
+			getExtension: vi.fn(() => ({ extensionUri: { fsPath: "/mock" } })),
+		},
+	}
+})
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		channel: { appendLine: vi.fn() },
+	}),
+}))
+
+vi.mock("../../../i18n", () => ({
+	t: vi.fn((key: string, options?: any) => {
+		if (options) return `${key} ${JSON.stringify(options)}`
+		return key
+	}),
+}))
+
+// Mock the roo-config to avoid real filesystem access
+vi.mock("../../../services/roo-config/index", () => ({
+	getGlobalCostrictDirectory: () => path.join(os.tmpdir(), "mock-costrict"),
+	getGlobalRooDirectory: () => path.join(os.tmpdir(), "mock-roo"),
+}))
+
+// Mock storage utils to avoid real filesystem access in ensureInstallerConfigured
+vi.mock("../../../../utils/storage", () => ({
+	getSettingsDirectoryPath: vi.fn().mockResolvedValue(path.join(os.tmpdir(), "mock-settings")),
+}))
+
+import { RemoteAgentInstaller } from "../RemoteAgentInstaller"
+import { InstallRecordManager } from "../InstallRecordManager"
+import { VersionApi } from "../VersionApi"
+import { AgentDownloader } from "../AgentDownloader"
+import { AgentInstaller } from "../AgentInstaller"
+import { FatalInstallerError } from "../types"
+import type { ResourcePackageVersion, LocalInstallRecord, InstalledManifest } from "../types"
+
+const defaultRecord: LocalInstallRecord = {
+	schemaVersion: 1,
+	installedVersion: "0.0.0",
+	lastCheckedAt: 0,
+	installState: "none",
+	manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+}
+
+describe("RemoteAgentInstaller orchestration flow", () => {
+	let tmpDir: string
+	let installer: RemoteAgentInstaller
+	let recordManagerMock: any
+	let versionApiMock: any
+	let downloaderMock: any
+	let resourceInstallerMock: any
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `rri-flow-test-${Date.now()}`)
+		await fs.mkdir(tmpDir, { recursive: true })
+		RemoteAgentInstaller["instance"] = undefined
+
+		// Create mocks for internal dependencies
+		recordManagerMock = {
+			read: vi.fn().mockResolvedValue({ ...defaultRecord }),
+			write: vi.fn().mockResolvedValue(undefined),
+			shouldCheck: vi.fn().mockReturnValue(true),
+		}
+		versionApiMock = {
+			getLatestVersion: vi.fn().mockResolvedValue(null),
+		}
+		downloaderMock = {
+			download: vi.fn().mockResolvedValue("/mock/path.zip"),
+			cleanupResidualFiles: vi.fn().mockResolvedValue(undefined),
+			getTmpDir: vi.fn().mockReturnValue(tmpDir),
+		}
+		resourceInstallerMock = {
+			install: vi.fn().mockResolvedValue({
+				agents: ["test-agent"],
+				commands: [],
+				skills: [],
+				rules: [],
+				mcp: [],
+			} as InstalledManifest),
+			uninstall: vi.fn().mockResolvedValue(undefined),
+			cleanup: vi.fn().mockResolvedValue(undefined),
+			getTmpDir: vi.fn().mockReturnValue(tmpDir),
+		}
+
+		installer = RemoteAgentInstaller.getInstance()
+
+		// Inject mocks via private field access
+		;(installer as any)["recordManager"] = recordManagerMock
+		;(installer as any)["versionApi"] = versionApiMock
+		;(installer as any)["downloader"] = downloaderMock
+		;(installer as any)["installer"] = resourceInstallerMock
+		// Mock lock methods to avoid real filesystem
+		;(installer as any)["isLockHeld"] = vi.fn().mockResolvedValue(false)
+		;(installer as any)["acquireLock"] = vi.fn().mockResolvedValue(undefined)
+		;(installer as any)["releaseLock"] = vi.fn().mockResolvedValue(undefined)
+		;(installer as any)["fileExists"] = vi.fn().mockResolvedValue(true)
+	})
+
+	afterEach(async () => {
+		installer.dispose()
+		RemoteAgentInstaller["instance"] = undefined
+		await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+		vi.clearAllMocks()
+	})
+
+	it("should return noUpdate when remote version equals local version", async () => {
+		recordManagerMock.read.mockResolvedValue({
+			...defaultRecord,
+			installedVersion: "1.0.0",
+		})
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "1.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const result = await installer.triggerManualInstall()
+
+		expect(result.state).toBe("noUpdate")
+		expect(downloaderMock.download).not.toHaveBeenCalled()
+	})
+
+	it("should return noUpdate when remote version is lower than local", async () => {
+		recordManagerMock.read.mockResolvedValue({
+			...defaultRecord,
+			installedVersion: "2.0.0",
+		})
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "1.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const result = await installer.triggerManualInstall()
+
+		expect(result.state).toBe("noUpdate")
+		expect(downloaderMock.download).not.toHaveBeenCalled()
+	})
+
+	it("should return noUpdate when server returns no downloadUrl", async () => {
+		// VersionApi.getLatestVersion() returns null when downloadUrl is absent —
+		// it never returns a ResourcePackageVersion without downloadUrl.
+		versionApiMock.getLatestVersion.mockResolvedValue(null)
+
+		const result = await installer.triggerManualInstall()
+
+		expect(result.state).toBe("noUpdate")
+		expect(recordManagerMock.write).toHaveBeenCalled()
+	})
+
+	it("should return noUpdate when server returns null", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue(null)
+
+		const result = await installer.triggerManualInstall()
+
+		expect(result.state).toBe("noUpdate")
+	})
+
+	it("should retry up to 3 times on non-fatal errors then fail", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+			checksum: "abc123",
+			checksumAlgo: "sha256",
+		} as ResourcePackageVersion)
+
+		// Mock download to always fail with a non-fatal error
+		downloaderMock.download.mockRejectedValue(new Error("Network timeout"))
+
+		// Speed up retry delays
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		const resultPromise = installer.triggerManualInstall()
+
+		// Allow all retries to complete (delays: 1s, 2s, 4s)
+		await vi.advanceTimersByTimeAsync(10_000)
+		const result = await resultPromise
+
+		expect(result.state).toBe("failed")
+		expect(result.reason).toBe("Network timeout")
+		expect(downloaderMock.download).toHaveBeenCalledTimes(3)
+
+		vi.useRealTimers()
+	})
+
+	it("should stop retrying immediately on FatalInstallerError", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		downloaderMock.download.mockResolvedValue("/mock/path.zip")
+		resourceInstallerMock.install.mockRejectedValue(
+			new FatalInstallerError("manifestMissing", "manifest.json is missing"),
+		)
+
+		const result = await installer.triggerManualInstall()
+
+		expect(result.state).toBe("failed")
+		expect(result.reason).toContain("manifest.json is missing")
+		// Should only attempt once (no retries for fatal errors)
+		expect(resourceInstallerMock.install).toHaveBeenCalledTimes(1)
+	})
+
+	it("should succeed on manual trigger with new version available", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+			checksum: "abc123",
+			checksumAlgo: "sha256",
+		} as ResourcePackageVersion)
+
+		const result = await installer.triggerManualInstall()
+
+		expect(result.state).toBe("installed")
+		expect(result.version).toBe("2.0.0")
+		expect(downloaderMock.download).toHaveBeenCalledTimes(1)
+		expect(resourceInstallerMock.install).toHaveBeenCalledTimes(1)
+		expect(recordManagerMock.write).toHaveBeenCalledWith(
+			expect.objectContaining({
+				installedVersion: "2.0.0",
+				installState: "installed",
+			}),
+		)
+	})
+
+	it("should succeed after transient failure on retry", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		// Fail first attempt, succeed on second
+		downloaderMock.download
+			.mockRejectedValueOnce(new Error("Temporary network error"))
+			.mockResolvedValue("/mock/path.zip")
+
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		const resultPromise = installer.triggerManualInstall()
+
+		await vi.advanceTimersByTimeAsync(5_000)
+		const result = await resultPromise
+
+		expect(result.state).toBe("installed")
+		expect(result.version).toBe("2.0.0")
+		expect(downloaderMock.download).toHaveBeenCalledTimes(2)
+
+		vi.useRealTimers()
+	})
+
+	// FR-012: lastCheckedAt must be updated after every check, even when no update is needed
+	it("should update lastCheckedAt when server returns null (no package available)", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue(null)
+
+		await installer.triggerManualInstall()
+
+		expect(recordManagerMock.write).toHaveBeenCalledWith(
+			expect.objectContaining({
+				lastCheckedAt: expect.any(Number),
+			}),
+		)
+		const writtenRecord = recordManagerMock.write.mock.calls[0][0]
+		expect(writtenRecord.lastCheckedAt).toBeGreaterThan(0)
+	})
+
+	// FR-012: lastCheckedAt must be updated when remote version equals local (no update needed)
+	it("should update lastCheckedAt when remote version equals local version", async () => {
+		recordManagerMock.read.mockResolvedValue({
+			...defaultRecord,
+			installedVersion: "1.0.0",
+		})
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "1.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		await installer.triggerManualInstall()
+
+		expect(recordManagerMock.write).toHaveBeenCalledWith(
+			expect.objectContaining({
+				lastCheckedAt: expect.any(Number),
+			}),
+		)
+	})
+
+	// FR-013: AgentInstaller.install() must call uninstall() before installing new modules
+	// This is verified at the AgentInstaller unit test level (see AgentInstaller.test.ts).
+	// At the orchestration level, we verify that install() is called (which internally calls uninstall).
+	it("should call AgentInstaller.install() which handles uninstall internally (FR-013)", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		await installer.triggerManualInstall()
+
+		// install() is called once — it internally calls uninstall() before installing
+		expect(resourceInstallerMock.install).toHaveBeenCalledTimes(1)
+		// The record passed to install() contains the current manifest for uninstall reference
+		expect(resourceInstallerMock.install).toHaveBeenCalledWith(
+			expect.any(String), // zipPath
+			expect.objectContaining({ version: "2.0.0" }), // versionInfo
+			expect.objectContaining({ installedVersion: "0.0.0" }), // record with manifest
+		)
+	})
+
+	// FR-015: background failure must trigger VSCode warning notification with Retry Now button
+	// Note: i18n mock returns the key suffix (e.g. "warn.downloadFailed" for "remoteAgentInstaller:warn.downloadFailed")
+	it("should show warning notification with Retry Now button on background network failure", async () => {
+		const vscode = await import("vscode")
+		const showWarningMock = vi.mocked(vscode.window.showWarningMessage)
+		showWarningMock.mockClear()
+		showWarningMock.mockResolvedValue(undefined)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const networkError = new Error("ETIMEDOUT")
+		;(networkError as any).code = "ETIMEDOUT"
+		downloaderMock.download.mockRejectedValue(networkError)
+
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		// Use performBackgroundCheck (isManual=false) path
+		const checkPromise = (installer as any).performBackgroundCheck(true)
+		await vi.advanceTimersByTimeAsync(10_000)
+		await checkPromise
+
+		// showWarningMessage must be called (background failure notification)
+		expect(showWarningMock).toHaveBeenCalled()
+		// Must be called with at least 2 args (message + Retry Now button)
+		const callArgs = showWarningMock.mock.calls[0]
+		expect(callArgs.length).toBeGreaterThanOrEqual(2)
+		// First arg is the warning message (contains "downloadFailed" key)
+		expect(String(callArgs[0])).toContain("downloadFailed")
+		// Second arg is the Retry Now button label
+		expect(String(callArgs[1])).toContain("retryNow")
+
+		vi.useRealTimers()
+	})
+
+	// FR-015: fatal error (content corrupted) shows warning WITHOUT Retry Now button
+	it("should show contentCorrupted warning without Retry Now button on FatalInstallerError in background", async () => {
+		const vscode = await import("vscode")
+		const showWarningMock = vi.mocked(vscode.window.showWarningMessage)
+		showWarningMock.mockClear()
+		showWarningMock.mockResolvedValue(undefined)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		downloaderMock.download.mockResolvedValue("/mock/path.zip")
+		resourceInstallerMock.install.mockRejectedValue(
+			new FatalInstallerError("manifestMissing", "manifest.json is missing"),
+		)
+
+		await (installer as any).performBackgroundCheck(true)
+
+		// Fatal error notification must be called
+		expect(showWarningMock).toHaveBeenCalled()
+		// Fatal error notification has no Retry Now button (only 1 argument = message only)
+		const callArgs = showWarningMock.mock.calls[0]
+		expect(callArgs.length).toBe(1)
+		// Message contains "contentCorrupted" key
+		expect(String(callArgs[0])).toContain("contentCorrupted")
+	})
+
+	// FR-015: manual install failure should NOT show background warning notification
+	it("should NOT show background warning notification on manual install failure", async () => {
+		const vscode = await import("vscode")
+		const showWarningMock = vi.mocked(vscode.window.showWarningMessage)
+		showWarningMock.mockClear()
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		// Use a non-network, non-disk error so notifyRetryableError won't show a warning
+		// (only network/disk errors trigger showWarningMessage in notifyRetryableError)
+		// Actually, any error triggers showWarningMessage in the else branch.
+		// The key distinction is: isManual=true → notifyRetryableError is NOT called.
+		downloaderMock.download.mockRejectedValue(new Error("Network error"))
+
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		// triggerManualInstall calls doInstall(true) → isManual=true → notifyRetryableError NOT called
+		const resultPromise = installer.triggerManualInstall()
+		await vi.advanceTimersByTimeAsync(10_000)
+		const result = await resultPromise
+
+		expect(result.state).toBe("failed")
+		// Manual install should NOT trigger background warning notification
+		expect(showWarningMock).not.toHaveBeenCalled()
+
+		vi.useRealTimers()
+	})
+
+	// FR-017: manual trigger must bypass 12h cooldown (shouldCheck=false should be ignored)
+	it("should bypass cooldown check on manual trigger (FR-017)", async () => {
+		// Simulate cooldown active: shouldCheck returns false
+		recordManagerMock.shouldCheck.mockReturnValue(false)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		// triggerManualInstall calls doInstall(true) which does NOT check shouldCheck
+		const result = await installer.triggerManualInstall()
+
+		// Should proceed with install despite cooldown
+		expect(result.state).toBe("installed")
+		expect(downloaderMock.download).toHaveBeenCalledTimes(1)
+	})
+
+	// FR-002: background check must respect 12h cooldown (shouldCheck=false → skip)
+	it("should skip background check when cooldown is active (shouldCheck=false)", async () => {
+		recordManagerMock.shouldCheck.mockReturnValue(false)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		// performBackgroundCheck(false) = timer-based check, respects cooldown
+		await (installer as any).performBackgroundCheck(false)
+
+		// Should skip entirely — no version check, no download
+		expect(versionApiMock.getLatestVersion).not.toHaveBeenCalled()
+		expect(downloaderMock.download).not.toHaveBeenCalled()
+	})
+
+	// FR-002: background check proceeds when cooldown is NOT active (shouldCheck=true)
+	it("should proceed with background check when cooldown is not active (shouldCheck=true)", async () => {
+		recordManagerMock.shouldCheck.mockReturnValue(true)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		await (installer as any).performBackgroundCheck(false)
+
+		expect(versionApiMock.getLatestVersion).toHaveBeenCalledTimes(1)
+	})
+
+	// Lock mechanism: background check must skip when lock is held by another process
+	it("should skip background install when lock is held by another process", async () => {
+		;(installer as any)["isLockHeld"] = vi.fn().mockResolvedValue(true)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const result = await (installer as any).doInstall(false)
+
+		// Background check returns noUpdate when lock is held
+		expect(result.state).toBe("noUpdate")
+		expect(downloaderMock.download).not.toHaveBeenCalled()
+	})
+
+	// Lock mechanism: manual install must fail with error when lock is held
+	it("should return failed state on manual install when lock is held", async () => {
+		;(installer as any)["isLockHeld"] = vi.fn().mockResolvedValue(true)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const result = await (installer as any).doInstall(true)
+
+		expect(result.state).toBe("failed")
+		expect(result.reason).toContain("Another process is currently installing")
+		expect(downloaderMock.download).not.toHaveBeenCalled()
+	})
+
+	// Lock mechanism: TOCTOU race — acquireLock throws EEXIST
+	it("should handle TOCTOU race condition when acquiring lock (EEXIST)", async () => {
+		;(installer as any)["isLockHeld"] = vi.fn().mockResolvedValue(false)
+		const eexistError = new Error("File exists") as any
+		eexistError.code = "EEXIST"
+		;(installer as any)["acquireLock"] = vi.fn().mockRejectedValue(eexistError)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const result = await (installer as any).doInstall(false)
+
+		expect(result.state).toBe("noUpdate")
+		expect(downloaderMock.download).not.toHaveBeenCalled()
+	})
+
+	// FR-011: after successful install, record must be updated with new version and installState=installed
+	it("should update LocalInstallRecord with new version and installState=installed after success", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "3.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		await installer.triggerManualInstall()
+
+		expect(recordManagerMock.write).toHaveBeenCalledWith(
+			expect.objectContaining({
+				installedVersion: "3.0.0",
+				installState: "installed",
+				lastCheckedAt: expect.any(Number),
+			}),
+		)
+	})
+
+	// FR-011: after all retries exhausted, record must be updated with installState=failed; lastCheckedAt must NOT be updated
+	it("should update LocalInstallRecord with installState=failed after all retries exhausted", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		downloaderMock.download.mockRejectedValue(new Error("Persistent failure"))
+
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		const resultPromise = installer.triggerManualInstall()
+		await vi.advanceTimersByTimeAsync(10_000)
+		await resultPromise
+
+		const failedWriteCall = recordManagerMock.write.mock.calls.find(
+			(call: any[]) => call[0]?.installState === "failed",
+		)
+		expect(failedWriteCall).toBeDefined()
+		expect(failedWriteCall![0]).toMatchObject({ installState: "failed" })
+		// lastCheckedAt must not be updated on install failure; value must remain unchanged from the original record
+		expect(failedWriteCall![0].lastCheckedAt).toBe(defaultRecord.lastCheckedAt)
+
+		vi.useRealTimers()
+	})
+
+	// Background check skips when another task is already running
+	it("should skip background check when install task is already running", async () => {
+		// Simulate a running promise
+		;(installer as any)["runningPromise"] = Promise.resolve()
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		await (installer as any).performBackgroundCheck(true)
+
+		// Should skip entirely since runningPromise is set
+		expect(versionApiMock.getLatestVersion).not.toHaveBeenCalled()
+	})
+
+	// P1 regression: when VersionApi returns null due to a NETWORK ERROR (not "no package"),
+	// lastCheckedAt must NOT be updated. Updating it would incorrectly reset the 12h cooldown,
+	// causing the next scheduled check to be skipped even though no successful check occurred.
+	//
+	// To distinguish "no package" from "network error", VersionApi must return a discriminated
+	// result instead of a plain null for both cases.
+	it("should NOT update lastCheckedAt when version check fails due to network error (P1)", async () => {
+		// Simulate a network error: VersionApi throws instead of returning null
+		versionApiMock.getLatestVersion.mockRejectedValue(new Error("ETIMEDOUT"))
+
+		// performBackgroundCheck should catch the error internally and NOT update lastCheckedAt
+		await (installer as any).performBackgroundCheck(true)
+
+		// lastCheckedAt must NOT be updated when the version check itself failed
+		expect(recordManagerMock.write).not.toHaveBeenCalled()
+	})
+
+	// P4 regression (corrected): when the file lock is held by another process, doInstall skips
+	// the install entirely — the version check result is irrelevant because no install was attempted.
+	// lastCheckedAt must NOT be updated in this case, so the 12h cooldown is not incorrectly reset.
+	// Resetting the cooldown would cause the next window to skip the check for another 12h even
+	// though the current window never actually performed the install.
+	it("should NOT update lastCheckedAt when lock is held by another process (P4 corrected)", async () => {
+		;(installer as any)["isLockHeld"] = vi.fn().mockResolvedValue(true)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		await (installer as any).doInstall(false)
+
+		// Lock was held → install was skipped → lastCheckedAt must NOT be updated
+		expect(recordManagerMock.write).not.toHaveBeenCalled()
+	})
+
+	// P4 regression (manual): same as above but for manual trigger
+	it("should NOT update lastCheckedAt when lock is held by another process on manual trigger (P4 corrected)", async () => {
+		;(installer as any)["isLockHeld"] = vi.fn().mockResolvedValue(true)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const result = await (installer as any).doInstall(true)
+
+		// Lock was held → install was skipped → lastCheckedAt must NOT be updated
+		expect(recordManagerMock.write).not.toHaveBeenCalled()
+		expect(result.state).toBe("failed")
+	})
+
+	// P5 fix: ensureInstallerConfigured() must pass downloader.getTmpDir() to the new AgentInstaller,
+	// so that installer.tmpDir always stays in sync with downloader.tmpDir.
+	// Without this fix, if downloader has a custom tmpDir, the newly created installer would use
+	// the default tmpDir instead, causing extractDir to be computed from a different base path.
+	it("should pass downloader.getTmpDir() to new AgentInstaller in ensureInstallerConfigured (P5)", async () => {
+		const customTmpDir = path.join(os.tmpdir(), "custom-downloader-tmp")
+
+		// Use a real AgentDownloader with a custom tmpDir
+		const realDownloader = new AgentDownloader(customTmpDir)
+		expect(realDownloader.getTmpDir()).toBe(customTmpDir)
+
+		// Inject the real downloader into the installer instance
+		;(installer as any)["downloader"] = realDownloader
+
+		// Mock context so ensureInstallerConfigured() runs the branch
+		const mockContext = {
+			globalStorageUri: { fsPath: path.join(os.tmpdir(), "mock-global-storage") },
+		}
+		;(installer as any)["context"] = mockContext
+
+		// Call ensureInstallerConfigured() — this creates a new AgentInstaller
+		await (installer as any).ensureInstallerConfigured()
+
+		// After configuration, installer.getTmpDir() must equal downloader.getTmpDir()
+		const newInstaller: AgentInstaller = (installer as any)["installer"]
+		expect(newInstaller.getTmpDir()).toBe(customTmpDir)
+	})
+
+	// P5 regression: unknown errors (no error code) in background should still show
+	// a warning notification WITH a Retry Now button, giving the user a chance to retry.
+	// Previously the else branch in notifyRetryableError omitted the Retry Now button.
+	it("should show installFailed warning WITH Retry Now button on background unknown error (P5)", async () => {
+		const vscode = await import("vscode")
+		const showWarningMock = vi.mocked(vscode.window.showWarningMessage)
+		showWarningMock.mockClear()
+		showWarningMock.mockResolvedValue(undefined)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		// Unknown error: no .code property → falls into else branch of notifyRetryableError
+		const unknownError = new Error("Unknown filesystem error")
+		downloaderMock.download.mockRejectedValue(unknownError)
+
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		const checkPromise = (installer as any).performBackgroundCheck(true)
+		await vi.advanceTimersByTimeAsync(10_000)
+		await checkPromise
+
+		// showWarningMessage must be called
+		expect(showWarningMock).toHaveBeenCalled()
+		// Must be called with at least 2 args (message + Retry Now button)
+		const callArgs = showWarningMock.mock.calls[0]
+		expect(callArgs.length).toBeGreaterThanOrEqual(2)
+		// First arg is the warning message (contains "installFailed" key)
+		expect(String(callArgs[0])).toContain("installFailed")
+		// Second arg is the Retry Now button label
+		expect(String(callArgs[1])).toContain("retryNow")
+
+		vi.useRealTimers()
+	})
+
+	// P1a: hasNotifiedFailure cross-cycle regression
+	// Bug: after background install fails and notifies user (hasNotifiedFailure=true),
+	// a second background install cycle that also fails should STILL send a new notification.
+	// Current code skips the second notification because hasNotifiedFailure is never reset
+	// between install cycles.
+	it("should reset hasNotifiedFailure so second background failure cycle also sends notification (P1a)", async () => {
+		const vscode = await import("vscode")
+		const showWarningMock = vi.mocked(vscode.window.showWarningMessage)
+		showWarningMock.mockClear()
+		showWarningMock.mockResolvedValue(undefined)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const networkError = new Error("ETIMEDOUT")
+		;(networkError as any).code = "ETIMEDOUT"
+		downloaderMock.download.mockRejectedValue(networkError)
+
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+
+		// --- First background install cycle: fails, notifies user ---
+		const check1 = (installer as any).performBackgroundCheck(true)
+		await vi.advanceTimersByTimeAsync(10_000)
+		await check1
+
+		// First notification must have been sent
+		expect(showWarningMock).toHaveBeenCalledTimes(1)
+		showWarningMock.mockClear()
+
+		// --- Second background install cycle: also fails ---
+		// hasNotifiedFailure should be reset at the start of each new install attempt,
+		// so the second failure should also trigger a notification.
+		const check2 = (installer as any).performBackgroundCheck(true)
+		await vi.advanceTimersByTimeAsync(10_000)
+		await check2
+
+		// Second notification MUST also be sent (this is the regression test)
+		expect(showWarningMock).toHaveBeenCalledTimes(1)
+
+		vi.useRealTimers()
+	})
+
+	// P1b: lastCheckedAt not updated when lock acquired but version already up-to-date
+	// Bug: in multi-process scenario, process B acquires lock and finds version already
+	// installed by process A (freshRecord.installedVersion >= versionInfo.version).
+	// It returns noUpdate without updating lastCheckedAt, so the 12h cooldown is not reset.
+	// This causes process B to re-check on the next activation instead of waiting 12h.
+	it("should update lastCheckedAt when version already up-to-date after acquiring lock (P1b)", async () => {
+		// Setup: remote version 2.0.0, initial local version 1.0.0 (triggers lock acquisition)
+		recordManagerMock.read
+			.mockResolvedValueOnce({ ...defaultRecord, installedVersion: "1.0.0" }) // first read: needs update
+			.mockResolvedValueOnce({ ...defaultRecord, installedVersion: "2.0.0" }) // second read (after lock): already up-to-date
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const result = await installer.triggerManualInstall()
+
+		// Should return noUpdate (version already installed by another process)
+		expect(result.state).toBe("noUpdate")
+
+		// lastCheckedAt MUST be updated (recordManager.write must be called with lastCheckedAt)
+		// This is the regression: currently write() is NOT called in this branch
+		expect(recordManagerMock.write).toHaveBeenCalled()
+		const writeCall = recordManagerMock.write.mock.calls[0][0]
+		expect(writeCall).toHaveProperty("lastCheckedAt")
+		expect(writeCall.lastCheckedAt).toBeGreaterThan(0)
+	})
+
+	// P6: disk errors (ENOSPC, EACCES, EPERM) should show installFailed warning WITH Retry Now button
+	// This verifies that the isDisk branch and else branch are equivalent and both show Retry Now.
+	it("should show installFailed warning WITH Retry Now button on background disk error (P6)", async () => {
+		const vscode = await import("vscode")
+		const showWarningMock = vi.mocked(vscode.window.showWarningMessage)
+		showWarningMock.mockClear()
+		showWarningMock.mockResolvedValue(undefined)
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		// Disk error: ENOSPC (no space left on device)
+		const diskError = new Error("ENOSPC: no space left on device")
+		;(diskError as any).code = "ENOSPC"
+		downloaderMock.download.mockRejectedValue(diskError)
+
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		const checkPromise = (installer as any).performBackgroundCheck(true)
+		await vi.advanceTimersByTimeAsync(10_000)
+		await checkPromise
+
+		// showWarningMessage must be called
+		expect(showWarningMock).toHaveBeenCalled()
+		// Must be called with at least 2 args (message + Retry Now button)
+		const callArgs = showWarningMock.mock.calls[0]
+		expect(callArgs.length).toBeGreaterThanOrEqual(2)
+		// First arg is the warning message (contains "installFailed" key)
+		expect(String(callArgs[0])).toContain("installFailed")
+		// Second arg is the Retry Now button label
+		expect(String(callArgs[1])).toContain("retryNow")
+
+		vi.useRealTimers()
+	})
+
+	// Requirement 1: background install success should show showInformationMessage
+	// Requirement 1: background install success should show showInformationMessage
+	it("should show showInformationMessage on background install success", async () => {
+		const vscode = await import("vscode")
+		const showInfoMock = vi.mocked(vscode.window.showInformationMessage)
+		showInfoMock.mockClear()
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		await (installer as any).performBackgroundCheck(true)
+
+		// showInformationMessage must be called for background install success
+		expect(showInfoMock).toHaveBeenCalled()
+		// The message should contain the "installed" key (i18n key suffix)
+		const callArgs = showInfoMock.mock.calls[0]
+		expect(String(callArgs[0])).toContain("installed")
+	})
+	// Requirement 1: manual install success should NOT show showInformationMessage inside runInstallWithRetries
+	// (registerCommands.ts handles the notification for manual installs)
+	it("should NOT show showInformationMessage inside runInstallWithRetries on manual install success", async () => {
+		const vscode = await import("vscode")
+		const showInfoMock = vi.mocked(vscode.window.showInformationMessage)
+		showInfoMock.mockClear()
+
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		} as ResourcePackageVersion)
+
+		const result = await installer.triggerManualInstall()
+		expect(result.state).toBe("installed")
+
+		// showInformationMessage must NOT be called inside runInstallWithRetries for manual installs
+		// (registerCommands.ts is responsible for showing the notification)
+		expect(showInfoMock).not.toHaveBeenCalled()
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.flow.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.flow.test.ts
@@ -844,3 +844,80 @@ describe("RemoteAgentInstaller orchestration flow", () => {
 		expect(showInfoMock).not.toHaveBeenCalled()
 	})
 })
+
+
+describe("RemoteAgentInstaller.forceBackgroundCheck flow (US-001)", () => {
+	let installer: RemoteAgentInstaller
+	let recordManagerMock: any
+	let versionApiMock: any
+	let downloaderMock: any
+	let resourceInstallerMock: any
+
+	beforeEach(async () => {
+		RemoteAgentInstaller["instance"] = undefined
+		installer = RemoteAgentInstaller.getInstance()
+
+		recordManagerMock = {
+			read: vi.fn().mockResolvedValue({ ...defaultRecord }),
+			write: vi.fn().mockResolvedValue(undefined),
+			shouldCheck: vi.fn().mockReturnValue(true),
+		}
+		versionApiMock = {
+			getLatestVersion: vi.fn().mockResolvedValue(null),
+		}
+		downloaderMock = {
+			download: vi.fn().mockResolvedValue("/mock/path.zip"),
+			cleanupResidualFiles: vi.fn().mockResolvedValue(undefined),
+			getTmpDir: vi.fn().mockReturnValue("/mock/tmp"),
+		}
+		resourceInstallerMock = {
+			install: vi.fn().mockResolvedValue({
+				agents: ["test-agent"],
+				commands: [],
+				skills: [],
+				rules: [],
+				mcp: [],
+			} as InstalledManifest),
+			uninstall: vi.fn().mockResolvedValue(undefined),
+			cleanup: vi.fn().mockResolvedValue(undefined),
+			getTmpDir: vi.fn().mockReturnValue("/mock/tmp"),
+		}
+
+		;(installer as any)["recordManager"] = recordManagerMock
+		;(installer as any)["versionApi"] = versionApiMock
+		;(installer as any)["downloader"] = downloaderMock
+		;(installer as any)["installer"] = resourceInstallerMock
+		;(installer as any)["isLockHeld"] = vi.fn().mockResolvedValue(false)
+		;(installer as any)["acquireLock"] = vi.fn().mockResolvedValue(undefined)
+		;(installer as any)["releaseLock"] = vi.fn().mockResolvedValue(undefined)
+		;(installer as any)["fileExists"] = vi.fn().mockResolvedValue(true)
+	})
+
+	afterEach(() => {
+		installer.dispose()
+		RemoteAgentInstaller["instance"] = undefined
+		vi.clearAllMocks()
+	})
+
+	// T011 [US1]: base_url 变更触发流程的集成风格测试
+	it("forceBackgroundCheck should execute doInstall when no task is running", async () => {
+		const doInstallSpy = vi.fn().mockResolvedValue({ state: "noUpdate" })
+		;(installer as any).doInstall = doInstallSpy
+
+		installer.forceBackgroundCheck()
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(doInstallSpy).toHaveBeenCalledWith(false)
+	})
+
+	it("forceBackgroundCheck should skip when a background check is already running", async () => {
+		const doInstallSpy = vi.fn().mockResolvedValue({ state: "noUpdate" })
+		;(installer as any).doInstall = doInstallSpy
+		installer["runningPromise"] = new Promise(() => {})
+
+		installer.forceBackgroundCheck()
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(doInstallSpy).not.toHaveBeenCalled()
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as os from "os"
+
+vi.mock("vscode", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("vscode")>()
+	return {
+		...actual,
+		window: {
+			...actual.window,
+			createOutputChannel: vi.fn(() => ({ appendLine: vi.fn(), dispose: vi.fn() })),
+			createStatusBarItem: vi.fn(() => ({ text: "", show: vi.fn(), hide: vi.fn(), dispose: vi.fn() })),
+			showInformationMessage: vi.fn(),
+			showWarningMessage: vi.fn(),
+			showErrorMessage: vi.fn(),
+		},
+		extensions: {
+			getExtension: vi.fn(() => ({ extensionUri: { fsPath: "/mock" } })),
+		},
+	}
+})
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		channel: { appendLine: vi.fn() },
+	}),
+}))
+
+import { RemoteAgentInstaller } from "../RemoteAgentInstaller"
+
+vi.mock("../../../i18n", () => ({
+	t: vi.fn((key: string, options?: any) => {
+		if (options) {
+			return `${key} ${JSON.stringify(options)}`
+		}
+		return key
+	}),
+}))
+
+describe("RemoteAgentInstaller", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = path.join(os.tmpdir(), `rri-test-${Date.now()}`)
+		await fs.mkdir(tmpDir, { recursive: true })
+		RemoteAgentInstaller["instance"] = undefined
+	})
+
+	afterEach(async () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		installer.dispose()
+		RemoteAgentInstaller["instance"] = undefined
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("should be a singleton", () => {
+		const a = RemoteAgentInstaller.getInstance()
+		const b = RemoteAgentInstaller.getInstance()
+		expect(a).toBe(b)
+	})
+
+	it("should return default package name", () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		expect(installer.getPackageName()).toBe("Remote Resource Package")
+	})
+
+	it("should skip manual install when task in progress", async () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		installer["runningPromise"] = new Promise(() => {})
+		const result = await installer.triggerManualInstall()
+		expect(result.state).toBe("failed")
+		expect(result.reason).toBe("Task in progress")
+	})
+
+	it("should skip manual uninstall when task in progress", async () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		installer["runningPromise"] = new Promise(() => {})
+		const result = await installer.triggerManualUninstall()
+		expect(result.success).toBe(false)
+		expect(result.reason).toBe("Task in progress")
+	})
+
+	it("should dispose without error", () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		expect(() => installer.dispose()).not.toThrow()
+	})
+
+	// Bug3 regression: after dispose(), scheduleNextCheck() must not schedule new timers.
+	it("should not schedule new timers after dispose", () => {
+		vi.useFakeTimers()
+		const installer = RemoteAgentInstaller.getInstance()
+		installer.dispose()
+		// Directly call scheduleNextCheck after dispose — it should be a no-op
+		;(installer as any).scheduleNextCheck()
+		// No setTimeout should have been registered
+		expect((installer as any).checkTimeout).toBeUndefined()
+		vi.useRealTimers()
+	})
+
+	// Bug3 regression: dispose() must set isDisposed = true as its first action.
+	it("should set isDisposed to true on dispose", () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		expect((installer as any).isDisposed).toBe(false)
+		installer.dispose()
+		expect((installer as any).isDisposed).toBe(true)
+	})
+
+	// Bug2 regression: scheduleBackgroundCheck() must call performBackgroundCheck(true)
+	// so that the activation-time check bypasses the 12h cooldown (FR-001).
+	it("scheduleBackgroundCheck should bypass 12h cooldown (forceCheck=true)", async () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		const performSpy = vi.fn().mockResolvedValue(undefined)
+		;(installer as any).performBackgroundCheck = performSpy
+		;(installer as any).scheduleNextCheck = vi.fn() // prevent real timer scheduling
+
+		installer.scheduleBackgroundCheck()
+		// Allow the async run() to execute
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(performSpy).toHaveBeenCalledWith(true)
+	})
+
+	// Bug2 regression: scheduleNextCheck() must call performBackgroundCheck(false)
+	// so that timer-based checks respect the 12h cooldown (FR-002).
+	it("scheduleNextCheck should respect 12h cooldown (forceCheck=false)", async () => {
+		vi.useFakeTimers()
+		const installer = RemoteAgentInstaller.getInstance()
+		const performSpy = vi.fn().mockResolvedValue(undefined)
+		;(installer as any).performBackgroundCheck = performSpy
+		// Override scheduleNextCheck to prevent infinite recursion after first call
+		let callCount = 0
+		const originalScheduleNextCheck = (installer as any).scheduleNextCheck.bind(installer)
+		;(installer as any).scheduleNextCheck = () => {
+			callCount++
+			if (callCount === 1) {
+				originalScheduleNextCheck()
+			}
+			// Stop after first real call to avoid infinite loop
+		}
+		;(installer as any).scheduleNextCheck()
+		// Advance past the 12h timer
+		await vi.advanceTimersByTimeAsync(12 * 60 * 60 * 1000 + 1000)
+
+		expect(performSpy).toHaveBeenCalledWith(false)
+		vi.useRealTimers()
+	})
+
+	// BUG-4 regression: dispose() must clear the singleton instance so that
+	// getInstance() returns a fresh instance after dispose().
+	it("should clear singleton instance after dispose", () => {
+		const installer = RemoteAgentInstaller.getInstance()
+		installer.dispose()
+		// After dispose, the static instance should be cleared
+		const newInstance = RemoteAgentInstaller.getInstance()
+		// The new instance should NOT be the disposed one
+		expect(newInstance).not.toBe(installer)
+		// The new instance should not be disposed
+		expect((newInstance as any).isDisposed).toBe(false)
+	})
+
+	// BUG-5 regression: getInstance() must update the context on an existing instance
+	// when a new context is provided. This prevents the following scenario:
+	//   1. registerCommands.ts calls getInstance() without context (instance created without context)
+	//   2. extension.ts calls getInstance(context) — but context is NOT applied to the existing instance
+	//   3. ensureInstallerConfigured() skips settingsDir because this.context is undefined
+	//   4. AgentInstaller uses ~/.roo/ instead of globalStorageUri — files written to wrong location
+	it("should update context on existing instance when getInstance is called with a new context", () => {
+		// Create instance without context first
+		const installer = RemoteAgentInstaller.getInstance()
+		expect((installer as any).context).toBeUndefined()
+
+		// Now call getInstance with a context — it should update the existing instance
+		const mockContext = { globalStorageUri: { fsPath: "/mock/storage" } } as any
+		const sameInstance = RemoteAgentInstaller.getInstance(mockContext)
+
+		// Should return the same singleton instance
+		expect(sameInstance).toBe(installer)
+		// Context should now be set on the existing instance
+		expect((sameInstance as any).context).toBe(mockContext)
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.test.ts
@@ -11,9 +11,9 @@ vi.mock("vscode", async (importOriginal) => {
 			...actual.window,
 			createOutputChannel: vi.fn(() => ({ appendLine: vi.fn(), dispose: vi.fn() })),
 			createStatusBarItem: vi.fn(() => ({ text: "", show: vi.fn(), hide: vi.fn(), dispose: vi.fn() })),
-			showInformationMessage: vi.fn(),
-			showWarningMessage: vi.fn(),
-			showErrorMessage: vi.fn(),
+			showInformationMessage: vi.fn(() => Promise.resolve(undefined)),
+			showWarningMessage: vi.fn(() => Promise.resolve(undefined)),
+			showErrorMessage: vi.fn(() => Promise.resolve(undefined)),
 		},
 		extensions: {
 			getExtension: vi.fn(() => ({ extensionUri: { fsPath: "/mock" } })),
@@ -181,5 +181,168 @@ describe("RemoteAgentInstaller", () => {
 		expect(sameInstance).toBe(installer)
 		// Context should now be set on the existing instance
 		expect((sameInstance as any).context).toBe(mockContext)
+	})
+})
+
+describe("RemoteAgentInstaller.forceBackgroundCheck (US-001)", () => {
+	let installer: RemoteAgentInstaller
+
+	beforeEach(() => {
+		RemoteAgentInstaller["instance"] = undefined
+		installer = RemoteAgentInstaller.getInstance()
+	})
+
+	afterEach(() => {
+		installer.dispose()
+		RemoteAgentInstaller["instance"] = undefined
+	})
+
+	// T008 [P] [US1]: forceBackgroundCheck 应调用 performBackgroundCheck(true)
+	it("forceBackgroundCheck should call performBackgroundCheck with forceCheck=true", async () => {
+		const performSpy = vi.fn().mockResolvedValue(undefined)
+		;(installer as any).performBackgroundCheck = performSpy
+		;(installer as any).scheduleNextCheck = vi.fn() // ensure no timer side effects
+
+		installer.forceBackgroundCheck()
+		// Allow the async run() to execute
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(performSpy).toHaveBeenCalledWith(true)
+	})
+
+	// T009 [P] [US1]: forceBackgroundCheck 不应调用 scheduleNextCheck
+	it("forceBackgroundCheck should not call scheduleNextCheck", async () => {
+		const performSpy = vi.fn().mockResolvedValue(undefined)
+		const scheduleSpy = vi.fn()
+		;(installer as any).performBackgroundCheck = performSpy
+		;(installer as any).scheduleNextCheck = scheduleSpy
+
+		installer.forceBackgroundCheck()
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(scheduleSpy).not.toHaveBeenCalled()
+	})
+
+	// T010 [P] [US1]: 当 runningPromise 存在时 forceBackgroundCheck 应直接跳过（不排队）
+	it("forceBackgroundCheck should be skipped when runningPromise exists", async () => {
+		const doInstallSpy = vi.fn()
+		;(installer as any).doInstall = doInstallSpy
+		installer["runningPromise"] = new Promise(() => {})
+
+		installer.forceBackgroundCheck()
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		// performBackgroundCheck sees runningPromise and returns early before calling doInstall
+		expect(doInstallSpy).not.toHaveBeenCalled()
+	})
+})
+
+describe("RemoteAgentInstaller background notification silence (US-002)", () => {
+	let installer: RemoteAgentInstaller
+	let recordManagerMock: any
+	let versionApiMock: any
+	let downloaderMock: any
+	let resourceInstallerMock: any
+	let vscodeWindow: typeof import("vscode").window
+
+	beforeEach(async () => {
+		RemoteAgentInstaller["instance"] = undefined
+		installer = RemoteAgentInstaller.getInstance()
+		vscodeWindow = await import("vscode").then((m) => m.window)
+
+		recordManagerMock = {
+			read: vi.fn().mockResolvedValue({
+				schemaVersion: 1,
+				installedVersion: "1.0.0",
+				lastCheckedAt: 0,
+				installState: "none",
+				manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+			}),
+			write: vi.fn().mockResolvedValue(undefined),
+			shouldCheck: vi.fn().mockReturnValue(true),
+		}
+		versionApiMock = {
+			getLatestVersion: vi.fn().mockResolvedValue(null),
+		}
+		downloaderMock = {
+			download: vi.fn().mockResolvedValue("/mock/path.zip"),
+			cleanupResidualFiles: vi.fn().mockResolvedValue(undefined),
+			getTmpDir: vi.fn().mockReturnValue("/mock/tmp"),
+		}
+		resourceInstallerMock = {
+			install: vi.fn().mockResolvedValue({
+				agents: [], commands: [], skills: [], rules: [], mcp: [],
+			}),
+			uninstall: vi.fn().mockResolvedValue(undefined),
+			cleanup: vi.fn().mockResolvedValue(undefined),
+			getTmpDir: vi.fn().mockReturnValue("/mock/tmp"),
+		}
+
+		;(installer as any)["recordManager"] = recordManagerMock
+		;(installer as any)["versionApi"] = versionApiMock
+		;(installer as any)["downloader"] = downloaderMock
+		;(installer as any)["installer"] = resourceInstallerMock
+		;(installer as any)["isLockHeld"] = vi.fn().mockResolvedValue(false)
+		;(installer as any)["acquireLock"] = vi.fn().mockResolvedValue(undefined)
+		;(installer as any)["releaseLock"] = vi.fn().mockResolvedValue(undefined)
+		;(installer as any)["fileExists"] = vi.fn().mockResolvedValue(true)
+	})
+
+	afterEach(() => {
+		installer.dispose()
+		RemoteAgentInstaller["instance"] = undefined
+		vi.clearAllMocks()
+	})
+
+	// T014 [P] [US2]: 后台 noUpdate 路径不调用 showInformationMessage / showWarningMessage
+	it("background noUpdate should not show any notification", async () => {
+		// Server returns null → noUpdate path in doInstall
+		versionApiMock.getLatestVersion.mockResolvedValue(null)
+
+		await (installer as any).doInstall(false)
+
+		vi.mocked(vscodeWindow.showWarningMessage).mockClear()
+		expect(vscodeWindow.showInformationMessage).not.toHaveBeenCalled()
+		expect(vscodeWindow.showWarningMessage).not.toHaveBeenCalled()
+	})
+
+	// T015 [P] [US2]: 后台 installed 路径调用 showInformationMessage
+	it("background installed should show information message", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+			name: "Test Package",
+		})
+		recordManagerMock.read.mockResolvedValue({
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		})
+
+		await (installer as any).doInstall(false)
+
+		expect(vscodeWindow.showInformationMessage).toHaveBeenCalled()
+	})
+
+	// T016 [P] [US2]: 后台 failed 路径调用 showWarningMessage
+	it("background failed should show warning message", async () => {
+		versionApiMock.getLatestVersion.mockResolvedValue({
+			version: "2.0.0",
+			downloadUrl: "https://example.com/pkg.zip",
+		})
+		recordManagerMock.read.mockResolvedValue({
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: 0,
+			installState: "none",
+			manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+		})
+		downloaderMock.download.mockRejectedValue(new Error("Network timeout"))
+
+		await (installer as any).doInstall(false)
+
+		expect(vscodeWindow.showWarningMessage).toHaveBeenCalled()
 	})
 })

--- a/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/RemoteAgentInstaller.test.ts
@@ -346,3 +346,65 @@ describe("RemoteAgentInstaller background notification silence (US-002)", () => 
 		expect(vscodeWindow.showWarningMessage).toHaveBeenCalled()
 	})
 })
+
+describe("RemoteAgentInstaller.triggerManualUninstall — hot-reload after uninstall", () => {
+	let installer: RemoteAgentInstaller
+	let recordManagerMock: any
+	let resourceInstallerMock: any
+
+	beforeEach(async () => {
+		RemoteAgentInstaller["instance"] = undefined
+		installer = RemoteAgentInstaller.getInstance()
+
+		recordManagerMock = {
+			read: vi.fn().mockResolvedValue({
+				schemaVersion: 1,
+				installedVersion: "1.0.0",
+				lastCheckedAt: 0,
+				installState: "installed",
+				manifest: { agents: ["test-agent"], commands: [], skills: [], rules: [], mcp: [] },
+			}),
+			write: vi.fn().mockResolvedValue(undefined),
+		}
+		resourceInstallerMock = {
+			uninstall: vi.fn().mockResolvedValue(undefined),
+			getTmpDir: vi.fn().mockReturnValue("/mock/tmp"),
+		}
+
+		;(installer as any)["recordManager"] = recordManagerMock
+		;(installer as any)["installer"] = resourceInstallerMock
+		;(installer as any)["ensureInstallerConfigured"] = vi.fn().mockResolvedValue(undefined)
+	})
+
+	afterEach(() => {
+		installer.dispose()
+		RemoteAgentInstaller["instance"] = undefined
+		vi.clearAllMocks()
+	})
+
+	// BUG regression: triggerManualUninstall() must call hotReloadAfterInstall() on success
+	// so that the webview mode dropdown immediately reflects the removed agents.
+	// Previously, hot-reload was only called after install, not after uninstall.
+	it("should call hotReloadAfterInstall after successful uninstall", async () => {
+		const hotReloadSpy = vi.fn().mockResolvedValue(undefined)
+		;(installer as any).hotReloadAfterInstall = hotReloadSpy
+
+		const result = await installer.triggerManualUninstall()
+
+		expect(result.success).toBe(true)
+		// hotReloadAfterInstall must be called so the webview dropdown updates immediately
+		expect(hotReloadSpy).toHaveBeenCalled()
+	})
+
+	// Verify that hot-reload is NOT called when uninstall fails
+	it("should NOT call hotReloadAfterInstall when uninstall fails", async () => {
+		const hotReloadSpy = vi.fn().mockResolvedValue(undefined)
+		;(installer as any).hotReloadAfterInstall = hotReloadSpy
+		resourceInstallerMock.uninstall.mockRejectedValue(new Error("Uninstall failed"))
+
+		const result = await installer.triggerManualUninstall()
+
+		expect(result.success).toBe(false)
+		expect(hotReloadSpy).not.toHaveBeenCalled()
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/VersionApi.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/VersionApi.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { VersionApi } from "../VersionApi"
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}))
+
+vi.mock("../../../shared/headers", () => ({
+	COSTRICT_DEFAULT_HEADERS: {},
+}))
+
+vi.mock("uuid", () => ({
+	v7: () => "mock-uuid",
+}))
+
+describe("VersionApi", () => {
+	let api: VersionApi
+
+	beforeEach(() => {
+		api = new VersionApi()
+		vi.restoreAllMocks()
+		vi.spyOn(api as any, "getBaseUrl").mockResolvedValue("https://api.example.com")
+		vi.spyOn(api as any, "getRequestHeaders").mockResolvedValue({
+			"Content-Type": "application/json",
+			"X-Request-ID": "mock-uuid",
+			"Accept-Language": "zh",
+			Authorization: "Bearer test-key",
+		})
+	})
+
+	it("should return null when response has no downloadUrl", async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "1.0.0" }),
+		})
+		const result = await api.getLatestVersion()
+		expect(result).toBeNull()
+	})
+
+	it("should throw for invalid semver", async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ version: "abc", downloadUrl: "https://example.com/pkg.zip" }),
+		})
+		await expect(api.getLatestVersion()).rejects.toThrow("Invalid or missing version")
+	})
+
+	it("should resolve absolute download url", async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				version: "1.2.3",
+				downloadUrl: "https://cdn.example.com/pkg.zip",
+				checksum: "abc123",
+				checksumAlgo: "sha256",
+			}),
+		})
+		const result = await api.getLatestVersion()
+		expect(result).not.toBeNull()
+		expect(result?.version).toBe("1.2.3")
+		expect(result?.downloadUrl).toBe("https://cdn.example.com/pkg.zip")
+	})
+
+	it("should resolve relative download url", async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				version: "1.0.0",
+				downloadUrl: "/pkg.zip",
+			}),
+		})
+		const result = await api.getLatestVersion()
+		expect(result?.downloadUrl).toBe("https://api.example.com/pkg.zip")
+	})
+
+	it("should throw on non-ok response", async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500,
+		})
+		await expect(api.getLatestVersion()).rejects.toThrow("HTTP 500")
+	})
+
+	it("should throw on fetch error", async () => {
+		global.fetch = vi.fn().mockRejectedValue(new Error("network error"))
+		await expect(api.getLatestVersion()).rejects.toThrow("network error")
+	})
+
+	// Bug5 regression: when costrictBaseUrl is empty, getLatestVersion should return null
+	// with a clear log message instead of throwing "TypeError: Failed to parse URL".
+	it("should return null and not throw when costrictBaseUrl is empty", async () => {
+		vi.spyOn(api as any, "getBaseUrl").mockResolvedValue("")
+		// fetch should NOT be called when baseUrl is empty
+		global.fetch = vi.fn()
+		const result = await api.getLatestVersion()
+		expect(result).toBeNull()
+		expect(global.fetch).not.toHaveBeenCalled()
+	})
+
+	it("should return null and not throw when costrictBaseUrl is undefined", async () => {
+		vi.spyOn(api as any, "getBaseUrl").mockResolvedValue("")
+		global.fetch = vi.fn()
+		const result = await api.getLatestVersion()
+		expect(result).toBeNull()
+		expect(global.fetch).not.toHaveBeenCalled()
+	})
+
+	// FR-003 / NFR-002: VersionApi must propagate timeout errors so callers can distinguish
+	// network failures from "no package available" (null return).
+	it("should throw when fetch times out (AbortError)", async () => {
+		const abortError = new DOMException("The operation was aborted.", "AbortError")
+		global.fetch = vi.fn().mockRejectedValue(abortError)
+		await expect(api.getLatestVersion()).rejects.toThrow()
+	})
+
+	// NFR-004: name field from server response should be preserved in returned object
+	it("should preserve name field from server response", async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				name: "Architecture Agent",
+				version: "2.0.0",
+				downloadUrl: "https://cdn.example.com/pkg.zip",
+			}),
+		})
+		const result = await api.getLatestVersion()
+		expect(result?.name).toBe("Architecture Agent")
+		expect(result?.version).toBe("2.0.0")
+	})
+
+	// FR-003: name field defaults gracefully when absent
+	it("should return result with undefined name when name is absent", async () => {
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				version: "1.5.0",
+				downloadUrl: "https://cdn.example.com/pkg.zip",
+			}),
+		})
+		const result = await api.getLatestVersion()
+		expect(result).not.toBeNull()
+		expect(result?.name).toBeUndefined()
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/integration.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/integration.test.ts
@@ -64,7 +64,8 @@ async function createTestZip(destPath: string): Promise<void> {
 	await fs.writeFile(path.join(srcDir, "rules", "test-rule", "rule.md"), "# Test Rule\n", "utf-8")
 	await fs.writeFile(
 		path.join(srcDir, "mcp", "test-server.json"),
-		JSON.stringify({ name: "test-server", url: "http://localhost:3000" }),
+		// use nested format (standard mcp_settings.json format)
+		JSON.stringify({ "test-server": { url: "http://localhost:3000" } }),
 		"utf-8",
 	)
 
@@ -310,7 +311,8 @@ describe("Remote Resource Installer Integration", () => {
 		const mcpZipPath = path.join(tmpDir, "mcp-only.zip")
 		await createZipWithModules(mcpZipPath, {
 			mcp: {
-				"my-server.json": JSON.stringify({ name: "my-server", command: "node", args: ["server.js"] }),
+				// costrict: use nested format (standard mcp_settings.json format)
+				"my-server.json": JSON.stringify({ "my-server": { command: "node", args: ["server.js"] } }),
 			},
 		})
 
@@ -338,7 +340,8 @@ describe("Remote Resource Installer Integration", () => {
 		const mcpZipPath = path.join(tmpDir, "mcp-merge.zip")
 		await createZipWithModules(mcpZipPath, {
 			mcp: {
-				"new-server.json": JSON.stringify({ name: "new-server", command: "node" }),
+				// costrict: use nested format (standard mcp_settings.json format)
+				"new-server.json": JSON.stringify({ "new-server": { command: "node" } }),
 			},
 		})
 
@@ -365,7 +368,8 @@ describe("Remote Resource Installer Integration", () => {
 		const mcpZipPath = path.join(tmpDir, "mcp-invalid.zip")
 		await createZipWithModules(mcpZipPath, {
 			mcp: {
-				"server.json": JSON.stringify({ name: "server", command: "node" }),
+				// use nested format (standard mcp_settings.json format)
+				"server.json": JSON.stringify({ server: { command: "node" } }),
 			},
 		})
 
@@ -387,10 +391,10 @@ describe("Remote Resource Installer Integration", () => {
 		const mcpZipPath = path.join(tmpDir, "mcp-non-obj.zip")
 		await createZipWithModules(mcpZipPath, {
 			mcp: {
-				// null value �?not an object, should be skipped
+				// null value — not an object, should be skipped
 				"null-server.json": "null",
-				// valid server
-				"valid-server.json": JSON.stringify({ name: "valid-server", command: "node" }),
+				// valid server — use nested format (standard mcp_settings.json format)
+				"valid-server.json": JSON.stringify({ "valid-server": { command: "node" } }),
 			},
 		})
 
@@ -931,8 +935,9 @@ describe("Remote Resource Installer Integration", () => {
 		const multiMcpZipPath = path.join(tmpDir, "multi-mcp.zip")
 		await createZipWithModules(multiMcpZipPath, {
 			mcp: {
-				"server-a.json": JSON.stringify({ name: "server-a", command: "node", args: ["a.js"] }),
-				"server-b.json": JSON.stringify({ name: "server-b", command: "python", args: ["b.py"] }),
+				// use nested format (standard mcp_settings.json format)
+				"server-a.json": JSON.stringify({ "server-a": { command: "node", args: ["a.js"] } }),
+				"server-b.json": JSON.stringify({ "server-b": { command: "python", args: ["b.py"] } }),
 			},
 		})
 

--- a/src/core/costrict/remote-agent-installer/__tests__/integration.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/integration.test.ts
@@ -1,0 +1,1021 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest"
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import * as path from "path"
+import * as os from "os"
+import * as http from "http"
+import * as crypto from "crypto"
+import { allowNetConnect } from "../../../../vitest.setup"
+
+vi.mock("vscode", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("vscode")>()
+	return {
+		...actual,
+		window: {
+			...actual.window,
+			createOutputChannel: vi.fn(() => ({ appendLine: vi.fn(), dispose: vi.fn() })),
+			createStatusBarItem: vi.fn(() => ({ text: "", show: vi.fn(), hide: vi.fn(), dispose: vi.fn() })),
+			showInformationMessage: vi.fn(),
+			showWarningMessage: vi.fn(),
+			showErrorMessage: vi.fn(),
+		},
+		extensions: {
+			getExtension: vi.fn(() => ({ extensionUri: { fsPath: "/mock" } })),
+		},
+	}
+})
+
+vi.mock("../../../utils/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		channel: { appendLine: vi.fn() },
+	}),
+}))
+
+import { AgentDownloader } from "../AgentDownloader"
+import { AgentInstaller } from "../AgentInstaller"
+import { FatalInstallerError } from "../types"
+import type { ResourcePackageVersion, LocalInstallRecord } from "../types"
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Create a full-featured test zip with all module types */
+async function createTestZip(destPath: string): Promise<void> {
+	const AdmZip = (await import("adm-zip")).default
+	const zip = new AdmZip()
+
+	const srcDir = path.join(path.dirname(destPath), "zip-src")
+	await fs.mkdir(path.join(srcDir, "agents"), { recursive: true })
+	await fs.mkdir(path.join(srcDir, "commands"), { recursive: true })
+	await fs.mkdir(path.join(srcDir, "skills", "test-skill"), { recursive: true })
+	await fs.mkdir(path.join(srcDir, "rules", "test-rule"), { recursive: true })
+	await fs.mkdir(path.join(srcDir, "mcp"), { recursive: true })
+
+	await fs.writeFile(
+		path.join(srcDir, "manifest.json"),
+		JSON.stringify({ version: "1.0.0", modules: ["agents", "commands", "skills", "rules", "mcp"] }),
+		"utf-8",
+	)
+	await fs.writeFile(path.join(srcDir, "agents", "test-agent.yaml"), "name: Test Agent\nslug: test-agent\n", "utf-8")
+	await fs.writeFile(path.join(srcDir, "commands", "test-command.md"), "# Test Command\n", "utf-8")
+	await fs.writeFile(path.join(srcDir, "skills", "test-skill", "skill.md"), "# Test Skill\n", "utf-8")
+	await fs.writeFile(path.join(srcDir, "rules", "test-rule", "rule.md"), "# Test Rule\n", "utf-8")
+	await fs.writeFile(
+		path.join(srcDir, "mcp", "test-server.json"),
+		JSON.stringify({ name: "test-server", url: "http://localhost:3000" }),
+		"utf-8",
+	)
+
+	zip.addLocalFolder(srcDir)
+	zip.writeZip(destPath)
+	await fs.rm(srcDir, { recursive: true, force: true })
+}
+
+/** Create a zip with custom modules map */
+async function createZipWithModules(
+	destPath: string,
+	modules: Record<string, Record<string, string>>,
+	version = "1.0.0",
+): Promise<void> {
+	const AdmZip = (await import("adm-zip")).default
+	const zip = new AdmZip()
+	const srcDir = path.join(path.dirname(destPath), `zip-src-${Date.now()}`)
+	await fs.mkdir(srcDir, { recursive: true })
+
+	await fs.writeFile(
+		path.join(srcDir, "manifest.json"),
+		JSON.stringify({ version, modules: Object.keys(modules) }),
+		"utf-8",
+	)
+
+	for (const [moduleName, files] of Object.entries(modules)) {
+		const moduleDir = path.join(srcDir, moduleName)
+		await fs.mkdir(moduleDir, { recursive: true })
+		for (const [fileName, content] of Object.entries(files)) {
+			const filePath = path.join(moduleDir, fileName)
+			await fs.mkdir(path.dirname(filePath), { recursive: true })
+			await fs.writeFile(filePath, content, "utf-8")
+		}
+	}
+
+	zip.addLocalFolder(srcDir)
+	zip.writeZip(destPath)
+	await fs.rm(srcDir, { recursive: true, force: true })
+}
+
+const defaultRecord: LocalInstallRecord = {
+	schemaVersion: 1,
+	installedVersion: "0.0.0",
+	lastCheckedAt: 0,
+	installState: "none",
+	manifest: { agents: [], commands: [], skills: [], rules: [], mcp: [] },
+}
+
+// ─── Main describe ───────────────────────────────────────────────────────────
+
+describe("Remote Resource Installer Integration", () => {
+	let tmpDir: string
+	let rooDir: string
+	let server: http.Server
+	let serverPort: number
+	let serverBaseUrl: string
+	let zipPath: string
+	let zipChecksum: string
+
+	beforeAll(async () => {
+		// Allow local HTTP server connections (nock blocks all by default)
+		allowNetConnect("127.0.0.1")
+
+		// Create temp directories
+		tmpDir = path.join(os.tmpdir(), `rri-integration-${Date.now()}`)
+		rooDir = path.join(tmpDir, "roo")
+		await fs.mkdir(tmpDir, { recursive: true })
+		await fs.mkdir(rooDir, { recursive: true })
+
+		// Build test zip package
+		zipPath = path.join(tmpDir, "remote-agent-package-1.0.0.zip")
+		await createTestZip(zipPath)
+
+		// Calculate checksum
+		const hash = crypto.createHash("sha256")
+		hash.update(fsSync.readFileSync(zipPath))
+		zipChecksum = hash.digest("hex")
+
+		// Start local HTTP server
+		server = http.createServer((req, res) => {
+			if (req.url === "/costrict-static/agent-package/latest.json") {
+				res.writeHead(200, { "Content-Type": "application/json" })
+				res.end(
+					JSON.stringify({
+						version: "1.0.0",
+						downloadUrl: `${serverBaseUrl}/remote-agent-package-1.0.0.zip`,
+						checksum: zipChecksum,
+						checksumAlgo: "sha256",
+					}),
+				)
+			} else if (req.url === "/remote-agent-package-1.0.0.zip") {
+				const data = fsSync.readFileSync(zipPath)
+				res.writeHead(200, {
+					"Content-Type": "application/zip",
+					"Content-Length": data.length,
+				})
+				res.end(data)
+			} else {
+				res.writeHead(404)
+				res.end("Not Found")
+			}
+		})
+
+		await new Promise<void>((resolve) => {
+			server.listen(0, "127.0.0.1", () => {
+				const addr = server.address()
+				if (addr && typeof addr === "object") {
+					serverPort = addr.port
+					serverBaseUrl = `http://127.0.0.1:${serverPort}`
+				}
+				resolve()
+			})
+		})
+	})
+
+	afterAll(async () => {
+		await new Promise<void>((resolve) => server.close(() => resolve()))
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	// ─── Download tests ──────────────────────────────────────────────────────
+
+	it("should download zip from local server with checksum verification", async () => {
+		const downloadDir = path.join(tmpDir, "download-test")
+		await fs.mkdir(downloadDir, { recursive: true })
+		const downloader = new AgentDownloader(downloadDir)
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: `${serverBaseUrl}/remote-agent-package-1.0.0.zip`,
+			checksum: zipChecksum,
+			checksumAlgo: "sha256",
+		}
+
+		const downloadedPath = await downloader.download(versionInfo)
+
+		expect(fsSync.existsSync(downloadedPath)).toBe(true)
+		expect(downloadedPath).toBe(path.join(downloadDir, "remote-agent-package-1.0.0.zip"))
+
+		// Verify downloaded file matches original
+		const originalHash = crypto.createHash("sha256").update(fsSync.readFileSync(zipPath)).digest("hex")
+		const downloadedHash = crypto.createHash("sha256").update(fsSync.readFileSync(downloadedPath)).digest("hex")
+		expect(downloadedHash).toBe(originalHash)
+	})
+
+	it("should fail download when checksum mismatches", async () => {
+		const downloadDir = path.join(tmpDir, "checksum-test")
+		await fs.mkdir(downloadDir, { recursive: true })
+		const downloader = new AgentDownloader(downloadDir)
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: `${serverBaseUrl}/remote-agent-package-1.0.0.zip`,
+			checksum: "invalidchecksum",
+			checksumAlgo: "sha256",
+		}
+
+		await expect(downloader.download(versionInfo)).rejects.toThrow("Checksum mismatch")
+	})
+
+	it("should fail download when server returns 404", async () => {
+		const downloadDir = path.join(tmpDir, "download-404-test")
+		await fs.mkdir(downloadDir, { recursive: true })
+		const downloader = new AgentDownloader(downloadDir)
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: `${serverBaseUrl}/nonexistent.zip`,
+		}
+
+		await expect(downloader.download(versionInfo)).rejects.toThrow()
+	})
+
+	it("should always re-download even when a zip with the same name already exists", async () => {
+		const downloadDir = path.join(tmpDir, "download-reuse-test")
+		await fs.mkdir(downloadDir, { recursive: true })
+		const downloader = new AgentDownloader(downloadDir)
+
+		// Pre-create a zip file with the same name to simulate a stale/partial download
+		const existingZipPath = path.join(downloadDir, "remote-agent-package-1.0.0.zip")
+		fsSync.copyFileSync(zipPath, existingZipPath)
+
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: `${serverBaseUrl}/remote-agent-package-1.0.0.zip`,
+			checksum: zipChecksum,
+			checksumAlgo: "sha256",
+		}
+
+		// AgentDownloader.download() always calls cleanupResidualFiles() first (deletes all
+		// remote-agent-package-* files), then re-downloads. The "cache reuse" logic (skipping download
+		// entirely) lives in RemoteAgentInstaller.runInstallWithRetries() via the zipPath variable.
+		// The returned path matches the expected destination path.
+		const downloadedPath = await downloader.download(versionInfo)
+		expect(downloadedPath).toBe(existingZipPath)
+	})
+
+	// ─── Install tests ───────────────────────────────────────────────────────
+
+	it("should install all modules from downloaded zip", async () => {
+		const installTmpDir = path.join(tmpDir, "install-test-tmp")
+		const installRooDir = path.join(tmpDir, "install-test-roo")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+
+		const installer = new AgentInstaller(installTmpDir, installRooDir)
+		const versionInfo: ResourcePackageVersion = { version: "1.0.0" }
+
+		const manifest = await installer.install(zipPath, versionInfo, { ...defaultRecord })
+
+		expect(manifest.agents).toContain("test-agent")
+		expect(manifest.commands).toContain("test-command.md")
+		expect(manifest.skills).toContain("test-skill")
+		expect(manifest.rules).toContain("test-rule")
+		expect(manifest.mcp).toContain("test-server")
+
+		// Verify agents YAML was written
+		const customModesPath = path.join(installRooDir, "custom_modes.yaml")
+		expect(fsSync.existsSync(customModesPath)).toBe(true)
+		const modesContent = fsSync.readFileSync(customModesPath, "utf-8")
+		expect(modesContent).toContain("test-agent")
+
+		// Verify commands were copied
+		const commandPath = path.join(installRooDir, "commands", "test-command.md")
+		expect(fsSync.existsSync(commandPath)).toBe(true)
+
+		// Verify skills were copied
+		const skillPath = path.join(installRooDir, "skills", "test-skill", "skill.md")
+		expect(fsSync.existsSync(skillPath)).toBe(true)
+
+		// Verify rules were copied (rules are installed directly under rooDir, not under "rules/")
+		const rulePath = path.join(installRooDir, "test-rule", "rule.md")
+		expect(fsSync.existsSync(rulePath)).toBe(true)
+	})
+
+	it("should install MCP server config into mcp_settings.json", async () => {
+		const installTmpDir = path.join(tmpDir, "mcp-install-tmp")
+		const installRooDir = path.join(tmpDir, "mcp-install-roo")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+
+		const mcpZipPath = path.join(tmpDir, "mcp-only.zip")
+		await createZipWithModules(mcpZipPath, {
+			mcp: {
+				"my-server.json": JSON.stringify({ name: "my-server", command: "node", args: ["server.js"] }),
+			},
+		})
+
+		const installer = new AgentInstaller(installTmpDir, installRooDir)
+		const manifest = await installer.install(mcpZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		expect(manifest.mcp).toContain("my-server")
+		// Verify mcp_settings.json was written with the server
+		const mcpSettingsPath = path.join(installRooDir, "mcp_settings.json")
+		expect(fsSync.existsSync(mcpSettingsPath)).toBe(true)
+		const settings = JSON.parse(fsSync.readFileSync(mcpSettingsPath, "utf-8"))
+		expect(settings.mcpServers).toHaveProperty("my-server")
+	})
+
+	it("should merge MCP server into existing mcp_settings.json", async () => {
+		const installTmpDir = path.join(tmpDir, "mcp-merge-tmp")
+		const installRooDir = path.join(tmpDir, "mcp-merge-roo")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+
+		// Pre-create existing mcp_settings.json with another server
+		const existingSettings = { mcpServers: { "existing-server": { command: "python" } } }
+		fsSync.writeFileSync(path.join(installRooDir, "mcp_settings.json"), JSON.stringify(existingSettings), "utf-8")
+
+		const mcpZipPath = path.join(tmpDir, "mcp-merge.zip")
+		await createZipWithModules(mcpZipPath, {
+			mcp: {
+				"new-server.json": JSON.stringify({ name: "new-server", command: "node" }),
+			},
+		})
+
+		const installer = new AgentInstaller(installTmpDir, installRooDir)
+		const manifest = await installer.install(mcpZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		expect(manifest.mcp).toContain("new-server")
+		// Verify both servers are in mcp_settings.json
+		const settings = JSON.parse(fsSync.readFileSync(path.join(installRooDir, "mcp_settings.json"), "utf-8"))
+		expect(settings.mcpServers).toHaveProperty("existing-server")
+		expect(settings.mcpServers).toHaveProperty("new-server")
+	})
+
+	it("should warn and continue (not throw) when local mcp_settings.json is corrupted", async () => {
+		const installTmpDir = path.join(tmpDir, "mcp-invalid-json-tmp")
+		const installRooDir = path.join(tmpDir, "mcp-invalid-json-roo")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+
+		// Write invalid JSON to local mcp_settings.json — this is a local config file,
+		// not zip content, so corruption should be auto-repaired (warn + reset to empty).
+		fsSync.writeFileSync(path.join(installRooDir, "mcp_settings.json"), "{ invalid json }", "utf-8")
+
+		const mcpZipPath = path.join(tmpDir, "mcp-invalid.zip")
+		await createZipWithModules(mcpZipPath, {
+			mcp: {
+				"server.json": JSON.stringify({ name: "server", command: "node" }),
+			},
+		})
+
+		const installer = new AgentInstaller(installTmpDir, installRooDir)
+		// Should NOT throw — corrupted local config is auto-repaired by overwriting with valid content
+		const manifest = await installer.install(mcpZipPath, { version: "1.0.0" }, { ...defaultRecord })
+		expect(manifest.mcp).toContain("server")
+		// Verify the corrupted file was repaired
+		const repairedContent = fsSync.readFileSync(path.join(installRooDir, "mcp_settings.json"), "utf-8")
+		expect(JSON.parse(repairedContent).mcpServers).toHaveProperty("server")
+	})
+
+	it("should skip MCP server config entry when server config is not an object", async () => {
+		const installTmpDir = path.join(tmpDir, "mcp-non-obj-tmp")
+		const installRooDir = path.join(tmpDir, "mcp-non-obj-roo")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+
+		const mcpZipPath = path.join(tmpDir, "mcp-non-obj.zip")
+		await createZipWithModules(mcpZipPath, {
+			mcp: {
+				// null value �?not an object, should be skipped
+				"null-server.json": "null",
+				// valid server
+				"valid-server.json": JSON.stringify({ name: "valid-server", command: "node" }),
+			},
+		})
+
+		const installer = new AgentInstaller(installTmpDir, installRooDir)
+		const manifest = await installer.install(mcpZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		// null-server should be skipped, valid-server should be installed
+		expect(manifest.mcp).not.toContain("null-server")
+		expect(manifest.mcp).toContain("valid-server")
+	})
+
+	it("should install rule as file (not directory) when rule is a single .md file", async () => {
+		const installTmpDir = path.join(tmpDir, "rule-file-tmp")
+		const installRooDir = path.join(tmpDir, "rule-file-roo")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+
+		const ruleZipPath = path.join(tmpDir, "rule-file.zip")
+		// Rules can be either directories or single files
+		await createZipWithModules(ruleZipPath, {
+			rules: {
+				"single-rule.md": "# Single Rule\nThis is a single file rule.\n",
+			},
+		})
+
+		const installer = new AgentInstaller(installTmpDir, installRooDir)
+		const manifest = await installer.install(ruleZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		expect(manifest.rules).toContain("single-rule.md")
+		// Verify the rule file was copied (rules are installed directly under rooDir)
+		const rulePath = path.join(installRooDir, "single-rule.md")
+		expect(fsSync.existsSync(rulePath)).toBe(true)
+	})
+
+	it("should uninstall rule that is a file (not directory)", async () => {
+		const uninstallRooDir = path.join(tmpDir, "uninstall-rule-file-roo")
+		await fs.mkdir(uninstallRooDir, { recursive: true })
+
+		// Create a rule as a single file directly under rooDir (not under "rules/")
+		const ruleFilePath = path.join(uninstallRooDir, "single-rule.md")
+		await fs.writeFile(ruleFilePath, "# Rule\n", "utf-8")
+
+		const installer = new AgentInstaller(tmpDir, uninstallRooDir)
+		const record: LocalInstallRecord = {
+			...defaultRecord,
+			installedVersion: "1.0.0",
+			installState: "installed",
+			manifest: {
+				agents: [],
+				commands: [],
+				skills: [],
+				rules: ["single-rule.md"],
+				mcp: [],
+			},
+		}
+
+		await installer.uninstall(record)
+
+		// The file should be removed
+		expect(fsSync.existsSync(ruleFilePath)).toBe(false)
+	})
+
+	it("should install agents to settingsDir when settingsDir is provided", async () => {
+		const installTmpDir = path.join(tmpDir, "settings-dir-tmp")
+		const installRooDir = path.join(tmpDir, "settings-dir-roo")
+		const settingsDir = path.join(tmpDir, "settings-dir-settings")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+		await fs.mkdir(settingsDir, { recursive: true })
+
+		const agentZipPath = path.join(tmpDir, "agent-settings.zip")
+		await createZipWithModules(agentZipPath, {
+			agents: {
+				"settings-agent.yaml": "name: Settings Agent\nslug: settings-agent\n",
+			},
+		})
+
+		const installer = new AgentInstaller(installTmpDir, installRooDir, settingsDir)
+		const manifest = await installer.install(agentZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		expect(manifest.agents).toContain("settings-agent")
+		// Agents should be in settingsDir, not rooDir
+		expect(fsSync.existsSync(path.join(settingsDir, "custom_modes.yaml"))).toBe(true)
+		expect(fsSync.existsSync(path.join(installRooDir, "custom_modes.yaml"))).toBe(false)
+	})
+
+	it("should install over existing installation (upgrade scenario)", async () => {
+		const installTmpDir = path.join(tmpDir, "upgrade-tmp")
+		const installRooDir = path.join(tmpDir, "upgrade-roo")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+
+		// First install
+		const installer = new AgentInstaller(installTmpDir, installRooDir)
+		const record1: LocalInstallRecord = { ...defaultRecord }
+		const manifest1 = await installer.install(zipPath, { version: "1.0.0" }, record1)
+		expect(manifest1.agents).toContain("test-agent")
+
+		// Second install (upgrade) �?should uninstall old and install new
+		const record2: LocalInstallRecord = {
+			...defaultRecord,
+			installedVersion: "1.0.0",
+			installState: "installed",
+			manifest: manifest1,
+		}
+		const manifest2 = await installer.install(zipPath, { version: "1.0.0" }, record2)
+		expect(manifest2.agents).toContain("test-agent")
+	})
+
+	// ─── Uninstall tests ─────────────────────────────────────────────────────
+
+	it("should uninstall previously installed modules", async () => {
+		const uninstallRooDir = path.join(tmpDir, "uninstall-test-roo")
+		await fs.mkdir(uninstallRooDir, { recursive: true })
+
+		const installer = new AgentInstaller(tmpDir, uninstallRooDir)
+		const record: LocalInstallRecord = {
+			schemaVersion: 1,
+			installedVersion: "1.0.0",
+			lastCheckedAt: Date.now(),
+			installState: "installed",
+			manifest: {
+				agents: ["test-agent"],
+				commands: ["test-command.md"],
+				skills: ["test-skill"],
+				rules: ["test-rule"],
+				mcp: ["test-server"],
+			},
+		}
+
+		// Pre-create installed files to simulate prior installation
+		// Rules are installed directly under rooDir (not under "rules/")
+		await fs.mkdir(path.join(uninstallRooDir, "commands"), { recursive: true })
+		await fs.mkdir(path.join(uninstallRooDir, "skills", "test-skill"), { recursive: true })
+		await fs.mkdir(path.join(uninstallRooDir, "test-rule"), { recursive: true })
+		await fs.writeFile(path.join(uninstallRooDir, "commands", "test-command.md"), "old", "utf-8")
+		await fs.writeFile(path.join(uninstallRooDir, "skills", "test-skill", "skill.md"), "old", "utf-8")
+		await fs.writeFile(path.join(uninstallRooDir, "test-rule", "rule.md"), "old", "utf-8")
+		await fs.writeFile(
+			path.join(uninstallRooDir, "custom_modes.yaml"),
+			"customModes:\n  - slug: test-agent\n",
+			"utf-8",
+		)
+		await fs.writeFile(
+			path.join(uninstallRooDir, "mcp_settings.json"),
+			JSON.stringify({ mcpServers: { "test-server": {} } }),
+			"utf-8",
+		)
+
+		await installer.uninstall(record)
+
+		// Verify files were removed
+		expect(fsSync.existsSync(path.join(uninstallRooDir, "commands", "test-command.md"))).toBe(false)
+		expect(fsSync.existsSync(path.join(uninstallRooDir, "skills", "test-skill"))).toBe(false)
+		expect(fsSync.existsSync(path.join(uninstallRooDir, "test-rule"))).toBe(false)
+	})
+
+	it("should uninstall gracefully when files are already missing", async () => {
+		const uninstallRooDir = path.join(tmpDir, "uninstall-missing-roo")
+		await fs.mkdir(uninstallRooDir, { recursive: true })
+
+		const installer = new AgentInstaller(tmpDir, uninstallRooDir)
+		const record: LocalInstallRecord = {
+			...defaultRecord,
+			installedVersion: "1.0.0",
+			installState: "installed",
+			manifest: {
+				agents: ["ghost-agent"],
+				commands: ["ghost-command.md"],
+				skills: ["ghost-skill"],
+				rules: ["ghost-rule"],
+				mcp: ["ghost-server"],
+			},
+		}
+
+		// No files pre-created �?should not throw
+		await expect(installer.uninstall(record)).resolves.not.toThrow()
+	})
+
+	it("should uninstall without manifest gracefully (null manifest)", async () => {
+		const uninstallRooDir = path.join(tmpDir, "uninstall-null-manifest-roo")
+		await fs.mkdir(uninstallRooDir, { recursive: true })
+
+		const installer = new AgentInstaller(tmpDir, uninstallRooDir)
+		const record: LocalInstallRecord = {
+			...defaultRecord,
+			installState: "none",
+			manifest: null as any,
+		}
+
+		await expect(installer.uninstall(record)).resolves.not.toThrow()
+	})
+
+	it("should remove agent from custom_modes.yaml on uninstall", async () => {
+		const uninstallRooDir = path.join(tmpDir, "uninstall-agent-yaml-roo")
+		await fs.mkdir(uninstallRooDir, { recursive: true })
+
+		// Pre-create custom_modes.yaml with multiple agents
+		await fs.writeFile(
+			path.join(uninstallRooDir, "custom_modes.yaml"),
+			"customModes:\n  - slug: keep-agent\n    name: Keep\n  - slug: remove-agent\n    name: Remove\n",
+			"utf-8",
+		)
+
+		const installer = new AgentInstaller(tmpDir, uninstallRooDir)
+		const record: LocalInstallRecord = {
+			...defaultRecord,
+			installedVersion: "1.0.0",
+			installState: "installed",
+			manifest: {
+				agents: ["remove-agent"],
+				commands: [],
+				skills: [],
+				rules: [],
+				mcp: [],
+			},
+		}
+
+		await installer.uninstall(record)
+
+		// custom_modes.yaml should still exist but without remove-agent
+		const content = fsSync.readFileSync(path.join(uninstallRooDir, "custom_modes.yaml"), "utf-8")
+		expect(content).toContain("keep-agent")
+		expect(content).not.toContain("remove-agent")
+	})
+
+	// ─── Cleanup tests ───────────────────────────────────────────────────────
+
+	it("should cleanup temporary files after install", async () => {
+		const cleanupTmpDir = path.join(tmpDir, "cleanup-tmp")
+		const cleanupRooDir = path.join(tmpDir, "cleanup-roo")
+		await fs.mkdir(cleanupTmpDir, { recursive: true })
+		await fs.mkdir(cleanupRooDir, { recursive: true })
+
+		const installer = new AgentInstaller(cleanupTmpDir, cleanupRooDir)
+		await installer.install(zipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		// After install, cleanup should remove extract dir
+		const extractDir = path.join(cleanupTmpDir, "remote-agent-package-1.0.0")
+		await installer.cleanup(undefined, extractDir)
+		expect(fsSync.existsSync(extractDir)).toBe(false)
+	})
+
+	it("should cleanup zip file when specified", async () => {
+		const cleanupTmpDir = path.join(tmpDir, "cleanup-zip-tmp")
+		await fs.mkdir(cleanupTmpDir, { recursive: true })
+
+		// Create a dummy zip to cleanup
+		const dummyZip = path.join(cleanupTmpDir, "dummy.zip")
+		await fs.writeFile(dummyZip, "dummy", "utf-8")
+
+		const installer = new AgentInstaller(cleanupTmpDir, rooDir)
+		await installer.cleanup(dummyZip, undefined)
+
+		expect(fsSync.existsSync(dummyZip)).toBe(false)
+	})
+
+	it("should not throw when cleanup targets do not exist", async () => {
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		await expect(installer.cleanup("/nonexistent/path.zip", "/nonexistent/extract-dir")).resolves.not.toThrow()
+	})
+
+	// ─── Error / edge case tests ─────────────────────────────────────────────
+
+	it("should throw FatalInstallerError on path traversal in zip", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const traversalZipPath = path.join(tmpDir, "traversal.zip")
+		const srcDir = path.join(tmpDir, "traversal-src")
+		await fs.mkdir(srcDir, { recursive: true })
+		await fs.writeFile(
+			path.join(srcDir, "manifest.json"),
+			JSON.stringify({ version: "1.0.0", modules: ["agents"] }),
+			"utf-8",
+		)
+		await fs.mkdir(path.join(srcDir, "agents"), { recursive: true })
+		await fs.writeFile(path.join(srcDir, "agents", "evil.yaml"), "name: evil\nslug: evil\n", "utf-8")
+
+		const zip = new AdmZip()
+		zip.addLocalFolder(srcDir)
+		zip.writeZip(traversalZipPath)
+		await fs.rm(srcDir, { recursive: true, force: true })
+
+		// Inject path traversal entry
+		const zip2 = new AdmZip(traversalZipPath)
+		zip2.addFile("/etc/evil.txt", Buffer.from("pwned"))
+		zip2.writeZip(traversalZipPath)
+
+		// Check if adm-zip preserved the traversal entry
+		const verifyZip = new AdmZip(traversalZipPath)
+		const hasTraversal = verifyZip.getEntries().some((e: any) => e.entryName.startsWith("/"))
+		if (!hasTraversal) {
+			// adm-zip normalizes entries on this platform �?skip
+			return
+		}
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		await expect(installer.install(traversalZipPath, { version: "1.0.0" }, { ...defaultRecord })).rejects.toThrow(
+			"path traversal",
+		)
+	})
+
+	it("should throw when zip has no manifest.json", async () => {
+		const AdmZip = (await import("adm-zip")).default
+		const noManifestZip = path.join(tmpDir, "no-manifest.zip")
+		const srcDir = path.join(tmpDir, "no-manifest-src")
+		await fs.mkdir(srcDir, { recursive: true })
+		await fs.mkdir(path.join(srcDir, "agents"), { recursive: true })
+		await fs.writeFile(path.join(srcDir, "agents", "test.yaml"), "name: test\nslug: test\n", "utf-8")
+
+		const zip = new AdmZip()
+		zip.addLocalFolder(srcDir)
+		zip.writeZip(noManifestZip)
+		await fs.rm(srcDir, { recursive: true, force: true })
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		await expect(installer.install(noManifestZip, { version: "1.0.0" }, { ...defaultRecord })).rejects.toThrow(
+			"manifest",
+		)
+	})
+
+	it("should throw when zip manifest version mismatches versionInfo", async () => {
+		const mismatchZipPath = path.join(tmpDir, "version-mismatch.zip")
+		await createZipWithModules(mismatchZipPath, {}, "0.5.0")
+
+		const installer = new AgentInstaller(tmpDir, rooDir)
+		await expect(installer.install(mismatchZipPath, { version: "1.0.0" }, { ...defaultRecord })).rejects.toThrow(
+			"version mismatch",
+		)
+	})
+
+	it("should throw FatalInstallerError when MCP JSON file is invalid", async () => {
+		const installTmpDir = path.join(tmpDir, "mcp-bad-json-tmp")
+		const installRooDir = path.join(tmpDir, "mcp-bad-json-roo")
+		await fs.mkdir(installTmpDir, { recursive: true })
+		await fs.mkdir(installRooDir, { recursive: true })
+
+		const badMcpZipPath = path.join(tmpDir, "mcp-bad-json.zip")
+		await createZipWithModules(badMcpZipPath, {
+			mcp: {
+				"bad.json": "{ not valid json !!!",
+			},
+		})
+
+		const installer = new AgentInstaller(installTmpDir, installRooDir)
+		await expect(installer.install(badMcpZipPath, { version: "1.0.0" }, { ...defaultRecord })).rejects.toThrow(
+			FatalInstallerError,
+		)
+	})
+
+	// ─── Download progress tests ─────────────────────────────────────────────
+
+	it("should report download progress during download", async () => {
+		const downloadDir = path.join(tmpDir, "progress-test")
+		await fs.mkdir(downloadDir, { recursive: true })
+		const downloader = new AgentDownloader(downloadDir)
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: `${serverBaseUrl}/remote-agent-package-1.0.0.zip`,
+			checksum: zipChecksum,
+			checksumAlgo: "sha256",
+		}
+
+		const progressValues: number[] = []
+		await downloader.download(versionInfo, (progress) => {
+			progressValues.push(progress.progress)
+		})
+
+		// Progress should have been reported at least once
+		expect(progressValues.length).toBeGreaterThan(0)
+		// Final progress should be 100
+		expect(progressValues[progressValues.length - 1]).toBe(100)
+	})
+
+	// ─── Lock mechanism tests (real filesystem) ──────────────────────────────
+
+	it("should detect expired lock and return false from isLockHeld", async () => {
+		const lockDir = path.join(tmpDir, "lock-expired-test")
+		await fs.mkdir(lockDir, { recursive: true })
+		const lockFilePath = path.join(lockDir, "remote-agent-package.lock")
+
+		// Write an expired lock (startTime far in the past)
+		const expiredLock = JSON.stringify({ pid: 99999, startTime: Date.now() - 60 * 60 * 1000 }) // 1 hour ago
+		await fs.writeFile(lockFilePath, expiredLock, "utf-8")
+
+		// Verify the lock file exists before the check
+		expect(fsSync.existsSync(lockFilePath)).toBe(true)
+
+		// Test the lock expiry logic directly
+		const data = await fs.readFile(lockFilePath, "utf-8")
+		const lock = JSON.parse(data) as { pid: number; startTime: number }
+		const LOCK_EXPIRE_MS = 30 * 60 * 1000
+		const isExpired = Date.now() - lock.startTime >= LOCK_EXPIRE_MS
+
+		expect(isExpired).toBe(true)
+	})
+
+	it("should detect active lock and return true from isLockHeld", async () => {
+		const lockDir = path.join(tmpDir, "lock-active-test")
+		await fs.mkdir(lockDir, { recursive: true })
+		const lockFilePath = path.join(lockDir, "remote-agent-package.lock")
+
+		// Write an active lock (startTime just now)
+		const activeLock = JSON.stringify({ pid: process.pid, startTime: Date.now() })
+		await fs.writeFile(lockFilePath, activeLock, "utf-8")
+
+		const data = await fs.readFile(lockFilePath, "utf-8")
+		const lock = JSON.parse(data) as { pid: number; startTime: number }
+		const LOCK_EXPIRE_MS = 30 * 60 * 1000
+		const isActive = Date.now() - lock.startTime < LOCK_EXPIRE_MS
+
+		expect(isActive).toBe(true)
+	})
+
+	// ─── End-to-end flow tests ───────────────────────────────────────────────
+
+	it("should complete full download-install-uninstall cycle", async () => {
+		const e2eTmpDir = path.join(tmpDir, "e2e-tmp")
+		const e2eRooDir = path.join(tmpDir, "e2e-roo")
+		await fs.mkdir(e2eTmpDir, { recursive: true })
+		await fs.mkdir(e2eRooDir, { recursive: true })
+
+		// Step 1: Download
+		const downloader = new AgentDownloader(e2eTmpDir)
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: `${serverBaseUrl}/remote-agent-package-1.0.0.zip`,
+			checksum: zipChecksum,
+			checksumAlgo: "sha256",
+		}
+		const downloadedZip = await downloader.download(versionInfo)
+		expect(fsSync.existsSync(downloadedZip)).toBe(true)
+
+		// Step 2: Install
+		const installer = new AgentInstaller(e2eTmpDir, e2eRooDir)
+		const manifest = await installer.install(downloadedZip, { version: "1.0.0" }, { ...defaultRecord })
+		expect(manifest.agents).toContain("test-agent")
+		expect(manifest.commands).toContain("test-command.md")
+		expect(manifest.skills).toContain("test-skill")
+		expect(manifest.rules).toContain("test-rule")
+		expect(manifest.mcp).toContain("test-server")
+
+		// Step 3: Verify files exist
+		expect(fsSync.existsSync(path.join(e2eRooDir, "commands", "test-command.md"))).toBe(true)
+		expect(fsSync.existsSync(path.join(e2eRooDir, "skills", "test-skill"))).toBe(true)
+
+		// Step 4: Uninstall
+		const uninstallRecord: LocalInstallRecord = {
+			...defaultRecord,
+			installedVersion: "1.0.0",
+			installState: "installed",
+			manifest,
+		}
+		await installer.uninstall(uninstallRecord)
+
+		// Step 5: Verify files removed
+		expect(fsSync.existsSync(path.join(e2eRooDir, "commands", "test-command.md"))).toBe(false)
+		expect(fsSync.existsSync(path.join(e2eRooDir, "skills", "test-skill"))).toBe(false)
+	})
+
+	it("should handle concurrent install attempts gracefully (idempotent)", async () => {
+		// Use separate directories for each concurrent install to avoid Windows EPERM
+		// on concurrent atomic renames of the same directory
+		const concurrent1TmpDir = path.join(tmpDir, "concurrent1-tmp")
+		const concurrent1RooDir = path.join(tmpDir, "concurrent1-roo")
+		const concurrent2TmpDir = path.join(tmpDir, "concurrent2-tmp")
+		const concurrent2RooDir = path.join(tmpDir, "concurrent2-roo")
+		await fs.mkdir(concurrent1TmpDir, { recursive: true })
+		await fs.mkdir(concurrent1RooDir, { recursive: true })
+		await fs.mkdir(concurrent2TmpDir, { recursive: true })
+		await fs.mkdir(concurrent2RooDir, { recursive: true })
+
+		const installer1 = new AgentInstaller(concurrent1TmpDir, concurrent1RooDir)
+		const installer2 = new AgentInstaller(concurrent2TmpDir, concurrent2RooDir)
+
+		// Run two installs concurrently �?both should succeed without corruption
+		const [manifest1, manifest2] = await Promise.all([
+			installer1.install(zipPath, { version: "1.0.0" }, { ...defaultRecord }),
+			installer2.install(zipPath, { version: "1.0.0" }, { ...defaultRecord }),
+		])
+
+		expect(manifest1.agents).toContain("test-agent")
+		expect(manifest2.agents).toContain("test-agent")
+	})
+
+	it("should install only agents module when zip has only agents", async () => {
+		const agentsOnlyTmpDir = path.join(tmpDir, "agents-only-tmp")
+		const agentsOnlyRooDir = path.join(tmpDir, "agents-only-roo")
+		await fs.mkdir(agentsOnlyTmpDir, { recursive: true })
+		await fs.mkdir(agentsOnlyRooDir, { recursive: true })
+
+		const agentsZipPath = path.join(tmpDir, "agents-only.zip")
+		await createZipWithModules(agentsZipPath, {
+			agents: {
+				"solo-agent.yaml": "name: Solo Agent\nslug: solo-agent\n",
+			},
+		})
+
+		const installer = new AgentInstaller(agentsOnlyTmpDir, agentsOnlyRooDir)
+		const manifest = await installer.install(agentsZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		expect(manifest.agents).toContain("solo-agent")
+		expect(manifest.commands).toEqual([])
+		expect(manifest.skills).toEqual([])
+		expect(manifest.rules).toEqual([])
+		expect(manifest.mcp).toEqual([])
+	})
+
+	it("should install multiple agents from a single zip", async () => {
+		const multiAgentTmpDir = path.join(tmpDir, "multi-agent-tmp")
+		const multiAgentRooDir = path.join(tmpDir, "multi-agent-roo")
+		await fs.mkdir(multiAgentTmpDir, { recursive: true })
+		await fs.mkdir(multiAgentRooDir, { recursive: true })
+
+		const multiAgentZipPath = path.join(tmpDir, "multi-agent.zip")
+		await createZipWithModules(multiAgentZipPath, {
+			agents: {
+				"agent-alpha.yaml": "name: Agent Alpha\nslug: agent-alpha\n",
+				"agent-beta.yaml": "name: Agent Beta\nslug: agent-beta\n",
+				"agent-gamma.yaml": "name: Agent Gamma\nslug: agent-gamma\n",
+			},
+		})
+
+		const installer = new AgentInstaller(multiAgentTmpDir, multiAgentRooDir)
+		const manifest = await installer.install(multiAgentZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		expect(manifest.agents).toContain("agent-alpha")
+		expect(manifest.agents).toContain("agent-beta")
+		expect(manifest.agents).toContain("agent-gamma")
+		expect(manifest.agents).toHaveLength(3)
+	})
+
+	it("should install multiple MCP servers from a single zip", async () => {
+		const multiMcpTmpDir = path.join(tmpDir, "multi-mcp-tmp")
+		const multiMcpRooDir = path.join(tmpDir, "multi-mcp-roo")
+		await fs.mkdir(multiMcpTmpDir, { recursive: true })
+		await fs.mkdir(multiMcpRooDir, { recursive: true })
+
+		const multiMcpZipPath = path.join(tmpDir, "multi-mcp.zip")
+		await createZipWithModules(multiMcpZipPath, {
+			mcp: {
+				"server-a.json": JSON.stringify({ name: "server-a", command: "node", args: ["a.js"] }),
+				"server-b.json": JSON.stringify({ name: "server-b", command: "python", args: ["b.py"] }),
+			},
+		})
+
+		const installer = new AgentInstaller(multiMcpTmpDir, multiMcpRooDir)
+		const manifest = await installer.install(multiMcpZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		expect(manifest.mcp).toContain("server-a")
+		expect(manifest.mcp).toContain("server-b")
+		expect(manifest.mcp).toHaveLength(2)
+	})
+
+	it("should uninstall multiple MCP servers from mcp_settings.json", async () => {
+		const uninstallMcpRooDir = path.join(tmpDir, "uninstall-mcp-roo")
+		await fs.mkdir(uninstallMcpRooDir, { recursive: true })
+
+		// Pre-create mcp_settings.json with multiple servers
+		const settings = {
+			mcpServers: {
+				"server-a": { command: "node" },
+				"server-b": { command: "python" },
+				"keep-server": { command: "ruby" },
+			},
+		}
+		await fs.writeFile(path.join(uninstallMcpRooDir, "mcp_settings.json"), JSON.stringify(settings), "utf-8")
+
+		const installer = new AgentInstaller(tmpDir, uninstallMcpRooDir)
+		const record: LocalInstallRecord = {
+			...defaultRecord,
+			installedVersion: "1.0.0",
+			installState: "installed",
+			manifest: {
+				agents: [],
+				commands: [],
+				skills: [],
+				rules: [],
+				mcp: ["server-a", "server-b"],
+			},
+		}
+
+		await installer.uninstall(record)
+
+		// Verify the mcp_settings.json was updated �?keep-server should remain
+		const updatedContent = fsSync.readFileSync(path.join(uninstallMcpRooDir, "mcp_settings.json"), "utf-8")
+		const updatedSettings = JSON.parse(updatedContent)
+		expect(updatedSettings.mcpServers).not.toHaveProperty("server-a")
+		expect(updatedSettings.mcpServers).not.toHaveProperty("server-b")
+		expect(updatedSettings.mcpServers).toHaveProperty("keep-server")
+	})
+
+	it("should handle download with no checksum (skip verification)", async () => {
+		const downloadDir = path.join(tmpDir, "no-checksum-test")
+		await fs.mkdir(downloadDir, { recursive: true })
+		const downloader = new AgentDownloader(downloadDir)
+		const versionInfo: ResourcePackageVersion = {
+			version: "1.0.0",
+			downloadUrl: `${serverBaseUrl}/remote-agent-package-1.0.0.zip`,
+			// No checksum provided
+		}
+
+		// Should succeed without checksum verification
+		const downloadedPath = await downloader.download(versionInfo)
+		expect(fsSync.existsSync(downloadedPath)).toBe(true)
+	})
+
+	it("should install rules as directories when rule is a directory", async () => {
+		const ruleDirTmpDir = path.join(tmpDir, "rule-dir-tmp")
+		const ruleDirRooDir = path.join(tmpDir, "rule-dir-roo")
+		await fs.mkdir(ruleDirTmpDir, { recursive: true })
+		await fs.mkdir(ruleDirRooDir, { recursive: true })
+
+		const ruleDirZipPath = path.join(tmpDir, "rule-dir.zip")
+		await createZipWithModules(ruleDirZipPath, {
+			rules: {
+				"my-rule/rule.md": "# My Rule\n",
+				"my-rule/extra.md": "# Extra\n",
+			},
+		})
+
+		const installer = new AgentInstaller(ruleDirTmpDir, ruleDirRooDir)
+		const manifest = await installer.install(ruleDirZipPath, { version: "1.0.0" }, { ...defaultRecord })
+
+		expect(manifest.rules).toContain("my-rule")
+		// Verify the rule directory was created directly under rooDir (not under "rules/")
+		expect(fsSync.existsSync(path.join(ruleDirRooDir, "my-rule"))).toBe(true)
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/utils.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/utils.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for shared utilities in the remote-agent-installer module.
+ * Covers: NFR-004 URL redaction (no sensitive tokens in logs).
+ *
+ * Note: URL.toString() URL-encodes special characters like < and >, so
+ * "<redacted>" becomes "%3Credacted%3E" in the output. We test that:
+ * 1. The original sensitive value is NOT present in the output.
+ * 2. The parameter key is still present (not removed entirely).
+ * 3. The replacement value contains "redacted" (either as-is or URL-encoded).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { redactUrl, getCheckIntervalMs } from "../utils"
+
+describe("redactUrl (NFR-004: no sensitive info in logs)", () => {
+	it("should redact token query parameter", () => {
+		const raw = "https://api.example.com/package.zip?token=abc123&version=1.0"
+		const result = redactUrl(raw)
+		// Sensitive value must not appear in output
+		expect(result).not.toContain("abc123")
+		// Parameter key must still be present
+		expect(result).toContain("token=")
+		// Replacement value must contain "redacted" (URL-encoded or plain)
+		expect(result.toLowerCase()).toContain("redacted")
+		// Non-sensitive params preserved
+		expect(result).toContain("version=1.0")
+	})
+
+	it("should redact auth query parameter", () => {
+		const raw = "https://api.example.com/package.zip?auth=secret-value"
+		const result = redactUrl(raw)
+		expect(result).not.toContain("secret-value")
+		expect(result).toContain("auth=")
+		expect(result.toLowerCase()).toContain("redacted")
+	})
+
+	it("should redact key query parameter", () => {
+		const raw = "https://api.example.com/package.zip?key=my-api-key"
+		const result = redactUrl(raw)
+		expect(result).not.toContain("my-api-key")
+		expect(result).toContain("key=")
+		expect(result.toLowerCase()).toContain("redacted")
+	})
+
+	it("should redact signature query parameter", () => {
+		const raw = "https://api.example.com/package.zip?signature=deadbeef"
+		const result = redactUrl(raw)
+		expect(result).not.toContain("deadbeef")
+		expect(result).toContain("signature=")
+		expect(result.toLowerCase()).toContain("redacted")
+	})
+
+	it("should redact multiple sensitive parameters at once", () => {
+		const raw = "https://api.example.com/pkg.zip?token=tok1&auth=auth1&key=key1&signature=sig1&version=2.0"
+		const result = redactUrl(raw)
+		// All sensitive values must be gone
+		expect(result).not.toContain("tok1")
+		expect(result).not.toContain("auth1")
+		expect(result).not.toContain("key1")
+		expect(result).not.toContain("sig1")
+		// Non-sensitive param preserved
+		expect(result).toContain("version=2.0")
+		// All sensitive keys still present (with redacted values)
+		expect(result).toContain("token=")
+		expect(result).toContain("auth=")
+		expect(result).toContain("key=")
+		expect(result).toContain("signature=")
+	})
+
+	it("should preserve URL path and non-sensitive query params", () => {
+		const raw = "https://api.example.com/costrict-static/agent-package/latest.json?version=1.0.0"
+		const result = redactUrl(raw)
+		expect(result).toContain("/costrict-static/agent-package/latest.json")
+		expect(result).toContain("version=1.0.0")
+	})
+
+	it("should return URL unchanged when no sensitive params present", () => {
+		const raw = "https://api.example.com/package.zip?version=1.0&format=zip"
+		const result = redactUrl(raw)
+		expect(result).toContain("version=1.0")
+		expect(result).toContain("format=zip")
+		// No redaction markers should appear
+		expect(result.toLowerCase()).not.toContain("redacted")
+	})
+
+	it("should return raw string unchanged when URL is invalid", () => {
+		const raw = "not-a-valid-url"
+		const result = redactUrl(raw)
+		expect(result).toBe(raw)
+	})
+
+	it("should handle URL with no query string", () => {
+		const raw = "https://api.example.com/package.zip"
+		const result = redactUrl(raw)
+		expect(result).toBe(raw)
+	})
+})
+
+describe("getCheckIntervalMs (COSTRICT_AGENT_CHECK_INTERVAL_MINUTES)", () => {
+	const ENV_KEY = "COSTRICT_AGENT_CHECK_INTERVAL_MINUTES"
+	const DEFAULT_MS = 12 * 60 * 60 * 1000 // 720 minutes = 12 hours
+
+	beforeEach(() => {
+		delete process.env[ENV_KEY]
+	})
+
+	afterEach(() => {
+		delete process.env[ENV_KEY]
+	})
+
+	it("should return default 12h when env var is not set", () => {
+		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
+	})
+
+	it("should return default 12h when env var is empty string", () => {
+		process.env[ENV_KEY] = ""
+		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
+	})
+
+	it("should return correct ms for a valid minute value (5 minutes)", () => {
+		process.env[ENV_KEY] = "5"
+		expect(getCheckIntervalMs()).toBe(5 * 60 * 1000)
+	})
+
+	it("should return correct ms for minimum value (1 minute)", () => {
+		process.env[ENV_KEY] = "1"
+		expect(getCheckIntervalMs()).toBe(1 * 60 * 1000)
+	})
+
+	it("should return correct ms for 720 minutes (12 hours)", () => {
+		process.env[ENV_KEY] = "720"
+		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
+	})
+
+	it("should fall back to default when value is 0 (below minimum)", () => {
+		process.env[ENV_KEY] = "0"
+		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
+	})
+
+	it("should fall back to default when value is negative", () => {
+		process.env[ENV_KEY] = "-5"
+		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
+	})
+
+	it("should fall back to default when value is non-numeric", () => {
+		process.env[ENV_KEY] = "abc"
+		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
+	})
+
+	it("should fall back to default when value is a float string", () => {
+		process.env[ENV_KEY] = "1.5"
+		// parseInt("1.5") = 1, which is >= MIN_MINUTES, so should return 1 minute
+		expect(getCheckIntervalMs()).toBe(1 * 60 * 1000)
+	})
+})

--- a/src/core/costrict/remote-agent-installer/__tests__/utils.test.ts
+++ b/src/core/costrict/remote-agent-installer/__tests__/utils.test.ts
@@ -97,7 +97,7 @@ describe("redactUrl (NFR-004: no sensitive info in logs)", () => {
 
 describe("getCheckIntervalMs (COSTRICT_AGENT_CHECK_INTERVAL_MINUTES)", () => {
 	const ENV_KEY = "COSTRICT_AGENT_CHECK_INTERVAL_MINUTES"
-	const DEFAULT_MS = 12 * 60 * 60 * 1000 // 720 minutes = 12 hours
+	const DEFAULT_MS = 60 * 60 * 1000 // 60 minutes = 1 hour
 
 	beforeEach(() => {
 		delete process.env[ENV_KEY]
@@ -107,11 +107,11 @@ describe("getCheckIntervalMs (COSTRICT_AGENT_CHECK_INTERVAL_MINUTES)", () => {
 		delete process.env[ENV_KEY]
 	})
 
-	it("should return default 12h when env var is not set", () => {
+	it("should return default 1h when env var is not set", () => {
 		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
 	})
 
-	it("should return default 12h when env var is empty string", () => {
+	it("should return default 1h when env var is empty string", () => {
 		process.env[ENV_KEY] = ""
 		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
 	})
@@ -128,7 +128,7 @@ describe("getCheckIntervalMs (COSTRICT_AGENT_CHECK_INTERVAL_MINUTES)", () => {
 
 	it("should return correct ms for 720 minutes (12 hours)", () => {
 		process.env[ENV_KEY] = "720"
-		expect(getCheckIntervalMs()).toBe(DEFAULT_MS)
+		expect(getCheckIntervalMs()).toBe(720 * 60 * 1000)
 	})
 
 	it("should fall back to default when value is 0 (below minimum)", () => {

--- a/src/core/costrict/remote-agent-installer/index.ts
+++ b/src/core/costrict/remote-agent-installer/index.ts
@@ -1,0 +1,14 @@
+// Public API: only export the main controller and necessary types
+export { RemoteAgentInstaller } from "./RemoteAgentInstaller"
+export type {
+	InstallResult,
+	UninstallResult,
+	InstallState,
+	ResourcePackageVersion,
+	LocalInstallRecord,
+	InstalledManifest,
+	ZipManifest,
+	ModuleType,
+	FatalErrorCode,
+} from "./types"
+export { FatalInstallerError } from "./types"

--- a/src/core/costrict/remote-agent-installer/types.ts
+++ b/src/core/costrict/remote-agent-installer/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Core type definitions for remote resource package installer.
+ */
+
+export interface ResourcePackageVersion {
+	name?: string
+	version: string
+	downloadUrl?: string
+	checksum?: string
+	checksumAlgo?: string
+}
+
+export type InstallState = "none" | "installed" | "failed"
+
+export interface InstalledManifest {
+	agents: string[]
+	commands: string[]
+	skills: string[]
+	rules: string[]
+	mcp: string[]
+}
+
+export interface LocalInstallRecord {
+	schemaVersion: number
+	installedVersion: string
+	lastCheckedAt: number
+	installState: InstallState
+	manifest: InstalledManifest
+}
+
+export interface ZipManifest {
+	version: string
+	modules?: string[]
+}
+
+export type ModuleType = "agents" | "commands" | "skills" | "rules" | "mcp"
+
+export interface InstallResult {
+	state: "installed" | "noUpdate" | "failed"
+	version?: string
+	reason?: string
+}
+
+export interface UninstallResult {
+	success: boolean
+	reason?: string
+}
+
+export type FatalErrorCode =
+	| "manifestMissing"
+	| "manifestParseError"
+	| "manifestVersionMismatch"
+	| "yamlParseError"
+	| "jsonParseError"
+	| "checksumMismatch"
+	| "pathTraversal"
+	| "reservedDeviceName"
+
+export class FatalInstallerError extends Error {
+	code: FatalErrorCode
+	constructor(code: FatalErrorCode, message: string) {
+		super(message)
+		this.name = "FatalInstallerError"
+		this.code = code
+	}
+}

--- a/src/core/costrict/remote-agent-installer/utils.ts
+++ b/src/core/costrict/remote-agent-installer/utils.ts
@@ -9,20 +9,16 @@ export function delay(ms: number): Promise<void> {
 }
 
 /**
- * Get the check interval in milliseconds.
- *
- * Reads from the environment variable `COSTRICT_AGENT_CHECK_INTERVAL_MINUTES`.
- * - Minimum: 1 minute (to prevent accidental abuse)
- * - Default: 12 hours (720 minutes)
- *
- * Example:
- *   COSTRICT_AGENT_CHECK_INTERVAL_MINUTES=5   → 5 minutes (for testing)
- *   COSTRICT_AGENT_CHECK_INTERVAL_MINUTES=720 → 12 hours (default)
- */
+ /**
+  * Get the check interval in milliseconds.
+  *
+  * Reads from the environment variable `COSTRICT_AGENT_CHECK_INTERVAL_MINUTES`.
+  * - Minimum: 1 minute (to prevent accidental abuse)
+  * - Default: 60 minutes (1 hour)
+  */
 export function getCheckIntervalMs(): number {
-	const DEFAULT_MINUTES = 12 * 60 // 720 minutes = 12 hours
+	const DEFAULT_MINUTES = 60
 	const MIN_MINUTES = 1
-
 	const raw = process.env.COSTRICT_AGENT_CHECK_INTERVAL_MINUTES
 	if (raw !== undefined && raw !== "") {
 		const parsed = parseInt(raw, 10)

--- a/src/core/costrict/remote-agent-installer/utils.ts
+++ b/src/core/costrict/remote-agent-installer/utils.ts
@@ -1,0 +1,49 @@
+import { URL } from "url"
+
+/**
+ * Shared utilities for the remote resource installer module.
+ */
+
+export function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Get the check interval in milliseconds.
+ *
+ * Reads from the environment variable `COSTRICT_AGENT_CHECK_INTERVAL_MINUTES`.
+ * - Minimum: 1 minute (to prevent accidental abuse)
+ * - Default: 12 hours (720 minutes)
+ *
+ * Example:
+ *   COSTRICT_AGENT_CHECK_INTERVAL_MINUTES=5   → 5 minutes (for testing)
+ *   COSTRICT_AGENT_CHECK_INTERVAL_MINUTES=720 → 12 hours (default)
+ */
+export function getCheckIntervalMs(): number {
+	const DEFAULT_MINUTES = 12 * 60 // 720 minutes = 12 hours
+	const MIN_MINUTES = 1
+
+	const raw = process.env.COSTRICT_AGENT_CHECK_INTERVAL_MINUTES
+	if (raw !== undefined && raw !== "") {
+		const parsed = parseInt(raw, 10)
+		if (!isNaN(parsed) && parsed >= MIN_MINUTES) {
+			return parsed * 60 * 1000
+		}
+	}
+	return DEFAULT_MINUTES * 60 * 1000
+}
+
+export function redactUrl(raw: string): string {
+	try {
+		const u = new URL(raw)
+		const sensitive = ["token", "auth", "key", "signature"]
+		sensitive.forEach((key) => {
+			if (u.searchParams.has(key)) {
+				u.searchParams.set(key, "<redacted>")
+			}
+		})
+		return u.toString()
+	} catch {
+		return raw
+	}
+}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2532,6 +2532,8 @@ export class ClineProvider
 	// Called by RemoteAgentInstaller after a successful remote agent package install.
 	public invalidateCustomModesCache(): void {
 		this.cachedCustomModes = undefined
+		//costrict: also clear CustomModesManager's TTL cache to avoid stale data after reinstall
+		this.customModesManager.clearCache()
 	}
 
 	private getCachedWorkspaceCommandList(configKey: "allowedCommands" | "deniedCommands"): string[] {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2528,6 +2528,12 @@ export class ClineProvider
 		return this.cachedCustomModes
 	}
 
+	// costrict: invalidate the in-memory custom modes cache so the next getState() re-reads from disk.
+	// Called by RemoteAgentInstaller after a successful remote agent package install.
+	public invalidateCustomModesCache(): void {
+		this.cachedCustomModes = undefined
+	}
+
 	private getCachedWorkspaceCommandList(configKey: "allowedCommands" | "deniedCommands"): string[] {
 		const cachedWorkspaceCommands = this.cachedWorkspaceCommandLists?.[configKey]
 		if (cachedWorkspaceCommands) {

--- a/src/core/webview/__tests__/invalidateCustomModesCache.spec.ts
+++ b/src/core/webview/__tests__/invalidateCustomModesCache.spec.ts
@@ -1,0 +1,57 @@
+// npx vitest core/webview/__tests__/invalidateCustomModesCache.spec.ts
+
+import { CustomModesManager } from "../../config/CustomModesManager"
+
+//costrict: lightweight host that mirrors the invalidateCustomModesCache logic from ClineProvider
+//         without instantiating the full ClineProvider (which requires heavy VSCode API mocks)
+type MinimalHost = {
+	cachedCustomModes: unknown
+	customModesManager: Pick<CustomModesManager, "clearCache">
+	invalidateCustomModesCache(): void
+}
+
+function makeHost(clearCacheSpy: ReturnType<typeof vi.fn>): MinimalHost {
+	return {
+		cachedCustomModes: [{ slug: "cached-mode" }],
+		customModesManager: { clearCache: clearCacheSpy } as unknown as CustomModesManager,
+		invalidateCustomModesCache() {
+			this.cachedCustomModes = undefined
+			//costrict: also clear CustomModesManager's TTL cache to avoid stale data after reinstall
+			this.customModesManager.clearCache()
+		},
+	}
+}
+
+describe("ClineProvider.invalidateCustomModesCache", () => {
+	it("should clear cachedCustomModes and call customModesManager.clearCache()", () => {
+		const clearCacheSpy = vi.fn()
+		const host = makeHost(clearCacheSpy)
+
+		expect(host.cachedCustomModes).toBeDefined()
+
+		host.invalidateCustomModesCache()
+
+		expect(host.cachedCustomModes).toBeUndefined()
+		expect(clearCacheSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it("should be idempotent: calling twice clears cache both times", () => {
+		const clearCacheSpy = vi.fn()
+		const host = makeHost(clearCacheSpy)
+
+		host.invalidateCustomModesCache()
+		host.invalidateCustomModesCache()
+
+		expect(host.cachedCustomModes).toBeUndefined()
+		expect(clearCacheSpy).toHaveBeenCalledTimes(2)
+	})
+
+	it("should still call clearCache even when cachedCustomModes is already undefined", () => {
+		const clearCacheSpy = vi.fn()
+		const host = makeHost(clearCacheSpy)
+		host.cachedCustomModes = undefined
+
+		expect(() => host.invalidateCustomModesCache()).not.toThrow()
+		expect(clearCacheSpy).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -34,6 +34,7 @@ import { type ApiMessage } from "../task-persistence/apiMessages"
 import { saveTaskMessages } from "../task-persistence"
 
 import { ClineProvider } from "./ClineProvider"
+import { RemoteAgentInstaller } from "../costrict/remote-agent-installer"
 import { handleCheckpointRestoreOperation } from "./checkpointRestoreHandler"
 import { generateErrorDiagnostics } from "./diagnosticsHandler"
 import {
@@ -2144,6 +2145,10 @@ export const webviewMessageHandler = async (
 			break
 		case "upsertApiConfiguration":
 			if (message.text && message.apiConfiguration) {
+				//costrict: read old costrictBaseUrl before saving (trimmed, empty-string normalized)
+				const oldConfig = (await provider.getState()).apiConfiguration
+				const oldBaseUrl = oldConfig?.costrictBaseUrl?.trim() || ""
+
 				if (message.apiConfiguration.apiProvider === "costrict") {
 					await provider.providerSettingsManager.saveMergeConfig(
 						{
@@ -2163,6 +2168,18 @@ export const webviewMessageHandler = async (
 						message.apiConfiguration?.costrictRefreshToken,
 					)
 				}
+
+				//costrict: read new costrictBaseUrl after saving (trimmed, empty-string normalized)
+				const newConfig = (await provider.getState()).apiConfiguration
+				const newBaseUrl = newConfig?.costrictBaseUrl?.trim() || ""
+
+				//costrict: trigger force background check only when base_url changed
+					if (oldBaseUrl !== newBaseUrl) {
+						provider.log(
+							`[webviewMessageHandler] costrictBaseUrl changed ("${oldBaseUrl}" → "${newBaseUrl}"), triggering remote agent install`,
+						)
+						RemoteAgentInstaller.getInstance().forceBackgroundCheck()
+					}
 			}
 			break
 		case "renameApiConfiguration":

--- a/src/i18n/locales/en/remoteAgentInstaller.json
+++ b/src/i18n/locales/en/remoteAgentInstaller.json
@@ -1,0 +1,20 @@
+{
+	"info": {
+		"installed": "{{name}} v{{version}} installed successfully.",
+		"noUpdate": "{{name}} is already up to date.",
+		"uninstalled": "{{name}} uninstalled successfully."
+	},
+	"warn": {
+		"taskInProgress": "{{name}} install is already in progress.",
+		"contentCorrupted": "{{name}} package content is corrupted. Please contact your administrator.",
+		"downloadFailed": "Failed to download {{name}}: {{reason}}",
+		"installFailed": "Failed to install {{name}}: {{reason}}"
+	},
+	"error": {
+		"updateFailed": "Failed to update {{name}}: {{reason}}",
+		"uninstallFailed": "Failed to uninstall {{name}}: {{reason}}"
+	},
+	"action": {
+		"retryNow": "Retry Now"
+	}
+}

--- a/src/i18n/locales/zh-CN/remoteAgentInstaller.json
+++ b/src/i18n/locales/zh-CN/remoteAgentInstaller.json
@@ -1,0 +1,20 @@
+{
+	"info": {
+		"installed": "{{name}} v{{version}} 安装成功。",
+		"noUpdate": "{{name}} 已是最新版本。",
+		"uninstalled": "{{name}} 卸载成功。"
+	},
+	"warn": {
+		"taskInProgress": "{{name}} 正在安装中，请稍候。",
+		"contentCorrupted": "{{name}} 安装包内容损坏，请联系管理员。",
+		"downloadFailed": "下载 {{name}} 失败：{{reason}}",
+		"installFailed": "安装 {{name}} 失败：{{reason}}"
+	},
+	"error": {
+		"updateFailed": "更新 {{name}} 失败：{{reason}}",
+		"uninstallFailed": "卸载 {{name}} 失败：{{reason}}"
+	},
+	"action": {
+		"retryNow": "立即重试"
+	}
+}

--- a/src/i18n/locales/zh-TW/remoteAgentInstaller.json
+++ b/src/i18n/locales/zh-TW/remoteAgentInstaller.json
@@ -1,0 +1,20 @@
+{
+	"info": {
+		"installed": "{{name}} v{{version}} 安裝成功。",
+		"noUpdate": "{{name}} 已是最新版本。",
+		"uninstalled": "{{name}} 解除安裝成功。"
+	},
+	"warn": {
+		"taskInProgress": "{{name}} 正在安裝中，請稍候。",
+		"contentCorrupted": "{{name}} 安裝包內容損壞，請聯繫管理員。",
+		"downloadFailed": "下載 {{name}} 失敗：{{reason}}",
+		"installFailed": "安裝 {{name}} 失敗：{{reason}}"
+	},
+	"error": {
+		"updateFailed": "更新 {{name}} 失敗：{{reason}}",
+		"uninstallFailed": "解除安裝 {{name}} 失敗：{{reason}}"
+	},
+	"action": {
+		"retryNow": "立即重試"
+	}
+}

--- a/src/package.json
+++ b/src/package.json
@@ -338,6 +338,16 @@
 				"command": "costrict.coworkflow.runTest",
 				"title": "Generate Test Case",
 				"category": "Coworkflow"
+			},
+			{
+				"command": "costrict.installAgentPackage",
+				"title": "%command.installAgentPackage.title%",
+				"category": "%configuration.title%"
+			},
+			{
+				"command": "costrict.uninstallAgentPackage",
+				"title": "%command.uninstallAgentPackage.title%",
+				"category": "%configuration.title%"
 			}
 		],
 		"menus": {
@@ -882,6 +892,7 @@
 		"@roo-code/telemetry": "workspace:^",
 		"@roo-code/types": "workspace:^",
 		"@vscode/codicons": "^0.0.45",
+		"adm-zip": "^0.5.16",
 		"ai-sdk-provider-poe": "2.0.18",
 		"async-mutex": "^0.5.0",
 		"async-retry": "^1.3.3",

--- a/src/package.json
+++ b/src/package.json
@@ -979,6 +979,7 @@
 		"@roo-code/build": "workspace:^",
 		"@roo-code/config-eslint": "workspace:^",
 		"@roo-code/config-typescript": "workspace:^",
+		"@types/adm-zip": "^0.5.8",
 		"@types/async-retry": "^1.4.9",
 		"@types/clone-deep": "^4.0.4",
 		"@types/debug": "^4.1.12",

--- a/src/package.nls.json
+++ b/src/package.nls.json
@@ -80,5 +80,19 @@
 	"settings.debug.description": "Enable debug mode to show additional buttons for viewing API conversation history and UI messages as prettified JSON in temporary files.",
 	"settings.debugProxy.enabled.description": "**Enable Debug Proxy** — Route all outbound network requests through a proxy for MITM debugging. Only active when running in debug mode (F5).",
 	"settings.debugProxy.serverUrl.description": "Proxy URL (e.g., `http://127.0.0.1:8888`). Only used when **Debug Proxy** is enabled.",
-	"settings.debugProxy.tlsInsecure.description": "Accept self-signed certificates from the proxy. **Required for MITM inspection.** ⚠️ Insecure — only use for local debugging."
+	"settings.debugProxy.tlsInsecure.description": "Accept self-signed certificates from the proxy. **Required for MITM inspection.** ⚠️ Insecure — only use for local debugging.",
+
+	"command.installAgentPackage.title": "Install/Update Remote Agent Package",
+	"command.uninstallAgentPackage.title": "Uninstall Remote Agent Package",
+
+	"remoteAgentInstaller:info.installed": "{name} updated to version {version}",
+	"remoteAgentInstaller:info.noUpdate": "{name} is already up to date",
+	"remoteAgentInstaller:error.updateFailed": "{name} update failed: {reason}",
+	"remoteAgentInstaller:info.uninstalled": "{name} uninstalled",
+	"remoteAgentInstaller:error.uninstallFailed": "{name} uninstall failed: {reason}",
+	"remoteAgentInstaller:warn.downloadFailed": "{name} download failed ({reason}). Please check your network and click 'Retry Now'",
+	"remoteAgentInstaller:warn.installFailed": "{name} installation failed ({reason}). Please check disk space and permissions, then click 'Retry Now'",
+	"remoteAgentInstaller:warn.contentCorrupted": "{name} content verification failed and cannot be installed automatically. Please wait for the server fix and try again later",
+	"remoteAgentInstaller:warn.taskInProgress": "{name} update is in progress, please try again later",
+	"remoteAgentInstaller:action.retryNow": "Retry Now"
 }

--- a/src/package.nls.zh-CN.json
+++ b/src/package.nls.zh-CN.json
@@ -82,5 +82,19 @@
 	"settings.debug.description": "启用调试模式以显示额外按钮，用于在临时文件中以格式化 JSON 查看 API 对话历史和 UI 消息。",
 	"settings.debugProxy.enabled.description": "**启用 Debug Proxy** — 通过代理转发所有出站网络请求，用于 MITM 调试。只在调试模式 (F5) 运行时生效。",
 	"settings.debugProxy.serverUrl.description": "代理 URL（例如 `http://127.0.0.1:8888`）。仅在启用 **Debug Proxy** 时使用。",
-	"settings.debugProxy.tlsInsecure.description": "接受来自代理的 self-signed 证书。**MITM 检查所必需。** ⚠️ 不安全——只在本地调试时使用。"
+	"settings.debugProxy.tlsInsecure.description": "接受来自代理的 self-signed 证书。**MITM 检查所必需。** ⚠️ 不安全——只在本地调试时使用。",
+
+	"command.installAgentPackage.title": "安装/更新远程 Agent 包",
+	"command.uninstallAgentPackage.title": "卸载远程 Agent 包",
+
+	"remoteAgentInstaller:info.installed": "{name} 已更新至版本 {version}",
+	"remoteAgentInstaller:info.noUpdate": "{name} 已是最新版本",
+	"remoteAgentInstaller:error.updateFailed": "{name} 更新失败：{reason}",
+	"remoteAgentInstaller:info.uninstalled": "{name} 已卸载",
+	"remoteAgentInstaller:error.uninstallFailed": "{name} 卸载失败：{reason}",
+	"remoteAgentInstaller:warn.downloadFailed": "{name} 下载失败（{reason}）。请检查网络后点击「立即重试」",
+	"remoteAgentInstaller:warn.installFailed": "{name} 安装失败（{reason}）。请检查磁盘空间和权限后点击「立即重试」",
+	"remoteAgentInstaller:warn.contentCorrupted": "{name} 内容校验失败，无法自动安装。请等待服务端修复后重试",
+	"remoteAgentInstaller:warn.taskInProgress": "{name} 更新正在进行中，请稍后再试",
+	"remoteAgentInstaller:action.retryNow": "立即重试"
 }

--- a/src/types/adm-zip.d.ts
+++ b/src/types/adm-zip.d.ts
@@ -1,0 +1,13 @@
+declare module "adm-zip" {
+	export default class AdmZip {
+		constructor(filePath?: string)
+		addFile(entryName: string, content: Buffer, comment?: string, attr?: number): void
+		addLocalFile(localPath: string, zipPath?: string): void
+		addLocalFolder(localPath: string, zipPath?: string): void
+		getEntries(): Array<{
+			entryName: string
+		}>
+		extractAllTo(targetPath: string, overwrite?: boolean): void
+		writeZip(targetFileName?: string, callback?: (error: Error | null) => void): void
+	}
+}

--- a/webview-ui/src/components/cloud/CostrictAccountView.tsx
+++ b/webview-ui/src/components/cloud/CostrictAccountView.tsx
@@ -241,6 +241,7 @@ const CostrictAccountViewComponent = ({ apiConfiguration, onDone }: AccountViewP
 	const { t } = useAppTranslation()
 	const { copyWithFeedback } = useCopyToClipboard()
 	const [quotaInfo, setQuotaInfo] = useState<QuotaInfo>()
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [inviteCodeInfo, setInviteCodeInfo] = useState<InviteCodeInfo>()
 	const [showQuotaInfo, setShowQuotaInfo] = useState(false)
 	const [isLoadingQuota, setIsLoadingQuota] = useState(false)


### PR DESCRIPTION
# feat: 远程 Agent 包自动安装与更新模块

## Summary

为 CoStrict 扩展新增远程 Agent 包自动下载、安装与更新系统（`remote-agent-installer`）。该模块支持从服务端拉取 zip 资源包，自动安装 agents、commands、skills、rules、mcp 五类模块到用户本地环境，并提供后台自动检查更新、手动安装/卸载、安装后热重载等完整生命周期管理。

### 核心功能

- **自动更新检查**：扩展启动后立即检查，之后按可配置间隔定期轮询（默认 60 分钟，可通过 `COSTRICT_AGENT_CHECK_INTERVAL_MINUTES` 环境变量自定义）
- **远程包下载**：从服务端下载 zip 包，支持 HTTP 重定向（最多 5 次）、进度回调、checksum 完整性校验
- **五类模块安装**：agents（YAML 合并到 custom_modes.yaml）、commands（md 文件复制）、skills（目录级安装 + `${skill_path}` 占位符替换）、rules（文件/目录安装）、mcp（JSON 合并到 mcp_settings.json）
- **安装后热重载**：安装成功后自动刷新 ClineProvider 的 customModes 缓存和 skills 发现，无需重启 VSCode
- **安全机制**：zip 路径穿越防护、Windows 保留设备名检测、checksum 校验、多窗口文件锁（30 分钟自动过期）、目标路径安全断言
- **健壮的错误处理**：安装失败指数退避重试（最多 3 次）、致命错误（manifest 缺失/版本不匹配/checksum 不匹配等）立即停止不重试、后台失败静默记录
- **安装/卸载后验证**：自动对比实际文件状态与安装记录，输出一致性校验结果

### 架构设计

```
RemoteAgentInstaller (单例，入口)
  ├── VersionApi              → 查询服务端最新版本信息
  ├── AgentDownloader         → 下载 zip + checksum 校验
  ├── AgentInstaller          → 解压 + 安装/卸载五类模块 + 验证
  └── InstallRecordManager    → 读写本地安装记录
```

## Changed Files

### 核心实现（8 个文件，~1,945 行）

| 文件 | 行数 | 说明 |
|------|------|------|
| `RemoteAgentInstaller.ts` | 547 | 主控制器：单例管理、后台检查调度、安装/卸载编排、锁机制、热重载 |
| `AgentInstaller.ts` | 805 | 安装器：zip 解压、五类模块安装/卸载、原子文件操作、安装后验证 |
| `AgentDownloader.ts` | 230 | 下载器：HTTP/HTTPS 下载、重定向、进度回调、checksum 校验、残留清理 |
| `VersionApi.ts` | 155 | 版本 API 客户端：查询 latest.json、URL 拼接、apiKey 认证 |
| `InstallRecordManager.ts` | 83 | 安装记录管理：读写本地 JSON 记录、冷却时间判断 |
| `types.ts` | 66 | 类型定义：版本信息、安装状态、manifest、致命错误码 |
| `utils.ts` | 45 | 工具函数：延迟、检查间隔配置解析 |
| `index.ts` | 14 | 公共 API 导出 |

### 测试（10 个文件，~4,459 行）

| 文件 | 行数 | 说明 |
|------|------|------|
| `integration.test.ts` | 1,026 | 端到端集成测试：真实 HTTP 服务器 + 真实文件操作 |
| `RemoteAgentInstaller.flow.test.ts` | 923 | 编排流程测试：版本比较、重试机制、致命错误处理、锁机制 |
| `AgentInstaller.edge.test.ts` | 883 | 安装器边界测试：安全防护、原子操作、异常路径 |
| `AgentInstaller.test.ts` | 444 | 安装器核心测试：安装/卸载、verifyUninstalled |
| `RemoteAgentInstaller.test.ts` | 410 | 单例、并发保护、dispose 行为测试 |
| `AgentInstaller.verify.test.ts` | 170 | 安装/卸载验证测试 |
| `InstallRecordManager.test.ts` | 166 | 安装记录读写、冷却时间判断测试 |
| `AgentDownloader.test.ts` | 135 | 下载器测试 |
| `utils.test.ts` | 154 | 工具函数测试 |
| `VersionApi.test.ts` | 148 | 版本 API 客户端测试 |

## Commit History

| Commit | 说明 |
|--------|------|
| `150b54883` | feat: remote agent install v1 — 初始实现 |
| `241e753c2` | feat: remote agent v2 — 功能完善 |
| `b5d105672` | feat: install remote agent v3 — 增加安全机制与热重载 |
| `35246950e` | fix: es lint — ESLint 修复 |
| `6b18a5853` | fix: set check interval to 60 min — 调整默认检查间隔 |

## Test Plan

- [ ] 验证后台自动检查在扩展启动时立即触发，之后按配置间隔定期执行
- [ ] 验证手动安装命令能正确下载、安装并热重载五类模块
- [ ] 验证手动卸载命令能正确清理所有已安装模块
- [ ] 验证多窗口并发安装时文件锁正确工作
- [ ] 验证致命错误（manifest 缺失、checksum 不匹配、路径穿越）被正确拒绝
- [ ] 验证非致命安装失败时指数退避重试机制
- [ ] 验证 `downloadUrl` 为空时客户端静默跳过
- [ ] 验证 `${skill_path}` 占位符在 skills 模块中被正确替换
- [ ] 验证安装后 customModes 和 skills 在 UI 中即时生效（无需重启）
- [ ] 运行全部单元测试：`cd src && npx vitest run core/costrict/remote-agent-installer/__tests__/`
