### PR TITLE
feat: costrict model list refresh

### DIFF
--- a/src/core/tools/__tests__/runSlashCommandTool.spec.ts
+++ b/src/core/tools/__tests__/runSlashCommandTool.spec.ts
@@ -31,7 +31,9 @@ describe("runSlashCommandTool", () => {
 							runSlashCommand: true,
 						},
 					}),
-					getSkillsManager: vi.fn().mockReturnValue(undefined),
+					ensureSkillsManager: vi.fn().mockResolvedValue({
+						getSkillContent: vi.fn().mockResolvedValue(null),
+					}),
 				}),
 			},
 		}
@@ -111,7 +113,7 @@ describe("runSlashCommandTool", () => {
 				},
 				mode: "code",
 			}),
-			getSkillsManager: vi.fn().mockReturnValue({
+			ensureSkillsManager: vi.fn().mockResolvedValue({
 				getSkillContent,
 			}),
 		})
@@ -179,7 +181,7 @@ Use skill workflow`,
 				},
 				mode: "code",
 			}),
-			getSkillsManager: vi.fn().mockReturnValue({
+			ensureSkillsManager: vi.fn().mockResolvedValue({
 				getSkillContent,
 			}),
 		})

--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useCallback, useEffect, useRef, useLayoutEffect } from "react"
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { Trans } from "react-i18next"
-import { ChevronsUpDown, Check, X, Brain, Info } from "lucide-react"
+import { ChevronsUpDown, Check, X, Brain, Info, RefreshCw } from "lucide-react"
 
 import { type ProviderSettings, type ModelInfo, type OrganizationAllowList, isRetiredProvider } from "@roo-code/types"
 
@@ -62,6 +62,10 @@ interface ModelPickerProps {
 	showLabel?: boolean
 	isChatBox?: boolean
 	isStreaming?: boolean
+	/** When provided, renders a refresh button in the dropdown search row that calls this on click. */
+	onRefreshModels?: () => void
+	/** Spins the refresh icon and disables the button while a refresh is in flight. */
+	isRefreshingModels?: boolean
 	triggerClassName?: string
 	popoverContentClassName?: string
 	PopoverTriggerContentClassName?: string
@@ -92,6 +96,8 @@ export const ModelPicker = ({
 	showInfoView = true,
 	showLabel = true,
 	isStreaming = false,
+	onRefreshModels,
+	isRefreshingModels = false,
 	triggerClassName = "",
 	popoverContentClassName = "",
 	PopoverTriggerContentClassName = "",
@@ -299,22 +305,40 @@ export const ModelPicker = ({
 						align="start"
 						data-testid={`model-picker-content${displayValue}`}>
 						<Command>
-							<div className="relative">
-								<CommandInput
-									ref={searchInputRef}
-									value={searchValue}
-									onValueChange={setSearchValue}
-									placeholder={t("settings:modelPicker.searchPlaceholder")}
-									className="h-9 mr-4"
-									data-testid="model-input"
-								/>
-								{searchValue.length > 0 && (
-									<div className="absolute right-2 top-0 bottom-0 flex items-center justify-center">
-										<X
-											className="text-vscode-input-foreground opacity-50 hover:opacity-100 size-4 p-0.5 cursor-pointer"
-											onClick={onClearSearch}
-										/>
-									</div>
+							<div className="flex items-stretch">
+								<div className="relative flex-1">
+									<CommandInput
+										ref={searchInputRef}
+										value={searchValue}
+										onValueChange={setSearchValue}
+										placeholder={t("settings:modelPicker.searchPlaceholder")}
+										className="h-9 mr-4"
+										data-testid="model-input"
+									/>
+									{searchValue.length > 0 && (
+										<div className="absolute right-2 top-0 bottom-0 flex items-center justify-center">
+											<X
+												className="text-vscode-input-foreground opacity-50 hover:opacity-100 size-4 p-0.5 cursor-pointer"
+												onClick={onClearSearch}
+											/>
+										</div>
+									)}
+								</div>
+								{onRefreshModels && (
+									<StandardTooltip content={t("settings:providers.refreshModels.label")}>
+										<button
+											type="button"
+											aria-label={t("settings:providers.refreshModels.label")}
+											data-testid="model-picker-refresh"
+											disabled={isRefreshingModels}
+											onClick={(e) => {
+												e.stopPropagation()
+												onRefreshModels()
+											}}
+											className="flex shrink-0 items-center justify-center self-stretch border-b border-vscode-dropdown-border px-2.5 text-vscode-input-foreground opacity-60 hover:opacity-100 disabled:cursor-default disabled:opacity-40 cursor-pointer">
+											<RefreshCw className={cn("size-4", isRefreshingModels && "animate-spin")} />
+										</button>
+									</StandardTooltip>
 								)}
 							</div>
 							<CommandList>

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { ModelPicker } from "./ModelPicker"
 
 import {
@@ -18,17 +19,7 @@ import {
 import { useDebounce, useEvent } from "react-use"
 import { vscode } from "@/utils/vscode"
 import { convertHeadersToObject } from "./utils/headers"
-import {
-	Select,
-	SelectTrigger,
-	SelectValue,
-	SelectContent,
-	SelectItem,
-	StandardTooltip,
-	Popover,
-	PopoverAnchor,
-	PopoverContent,
-} from "@src/components/ui"
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, StandardTooltip } from "@src/components/ui"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { useSelectedModel } from "../ui/hooks/useSelectedModel"
 import { Brain, Info, X } from "lucide-react"
@@ -348,101 +339,99 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			? `${t("settings:modelPicker.label")}: ${defaultModelId}`
 			: t("chat:selectModel")
 	return (
-		<Popover open={!!autoSwitchNotice} onOpenChange={(o) => !o && setAutoSwitchNotice(null)}>
-			<PopoverAnchor asChild>
-				<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
-					{config?.modelIdKey ? (
-						<ModelPicker
-							isChatBox={true}
-							modelPickerId={isEditMode ? "modelPickerEdit" : "modelPicker"}
-							apiConfiguration={apiConfiguration}
-							setApiConfigurationField={setApiConfigurationFieldWithRef}
-							defaultModelId={defaultModelId}
-							models={config?.models ?? {}}
-							modelIdKey={config.modelIdKey as any}
-							serviceName={config.serviceName}
-							serviceUrl={config.serviceUrl}
-							organizationAllowList={organizationAllowList}
-							showInfoView={false}
-							showLabel={false}
-							isStreaming={isStreaming}
-							onRefreshModels={selectedProvider === "costrict" ? handleRefreshModels : undefined}
-							isRefreshingModels={isRefreshing}
-							triggerClassName="rounded-md max-w-80 px-[6px] text-xs h-6 opacity-90 hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)] cursor-pointer transition-all duration-150"
-							popoverContentClassName="min-w-80 max-w-9/10 overflow-hidden text-xs"
-							tooltip={tooltip}
-						/>
-					) : (
-						selectedProviderModels.length > 0 && (
-							<StandardTooltip content={tooltip}>
-								<div>
-									<Select
-										open={showSelect}
-										disabled={isStreaming}
-										value={selectedModelId === "custom-arn" ? "custom-arn" : selectedModelId}
-										onValueChange={(value) => {
-											setApiConfigurationField(
-												apiConfiguration.apiProvider === "costrict"
-													? "costrictModelId"
-													: "apiModelId",
-												value,
-											)
-
-											// Clear custom ARN if not using custom ARN option.
-											if (value !== "custom-arn" && selectedProvider === "bedrock") {
-												setApiConfigurationField("awsCustomArn", "")
-											}
-										}}
-										onOpenChange={(open) => {
-											setShowSelect(open)
-										}}>
-										<SelectTrigger
-											className={cn(
-												"rounded-md w-full h-6 px-1.5 opacity-90 hover:opacity-100 bg-vscode-input-background hover:border-[rgba(255,255,255,0.15)]",
-											)}
-											showIcon={false}>
-											<span className=" overflow-hidden text-ellipsis whitespace-nowrap">
-												<Brain className="inline-block mr-1" />
-												<SelectValue placeholder={t("settings:common.select")} />
-											</span>
-										</SelectTrigger>
-										<SelectContent className="min-w-80 max-w-9/10 overflow-hidden">
-											{selectedProviderModels.map((option) => (
-												<SelectItem key={option.value} value={option.value}>
-													{option.label}
-												</SelectItem>
-											))}
-											{selectedProvider === "bedrock" && (
-												<SelectItem value="custom-arn">
-													{t("settings:labels.useCustomArn")}
-												</SelectItem>
-											)}
-										</SelectContent>
-									</Select>
-								</div>
-							</StandardTooltip>
-						)
-					)}
-				</div>
-			</PopoverAnchor>
-			{autoSwitchNotice && noticePortalContainer && (
-				<PopoverContent
-					container={noticePortalContainer}
-					side="top"
-					align="start"
-					onOpenAutoFocus={(e) => e.preventDefault()}
-					className="z-50 flex w-auto max-w-80 items-center gap-1 whitespace-normal rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-2 py-1 text-xs text-vscode-descriptionForeground shadow">
-					<Info className="size-3 shrink-0" />
-					<span className="flex-1">
-						{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}
-					</span>
-					<X
-						className="size-3 shrink-0 cursor-pointer opacity-70 hover:opacity-100"
-						onClick={() => setAutoSwitchNotice(null)}
+		<>
+			<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
+				{config?.modelIdKey ? (
+					<ModelPicker
+						isChatBox={true}
+						modelPickerId={isEditMode ? "modelPickerEdit" : "modelPicker"}
+						apiConfiguration={apiConfiguration}
+						setApiConfigurationField={setApiConfigurationFieldWithRef}
+						defaultModelId={defaultModelId}
+						models={config?.models ?? {}}
+						modelIdKey={config.modelIdKey as any}
+						serviceName={config.serviceName}
+						serviceUrl={config.serviceUrl}
+						organizationAllowList={organizationAllowList}
+						showInfoView={false}
+						showLabel={false}
+						isStreaming={isStreaming}
+						onRefreshModels={selectedProvider === "costrict" ? handleRefreshModels : undefined}
+						isRefreshingModels={isRefreshing}
+						triggerClassName="rounded-md max-w-80 px-[6px] text-xs h-6 opacity-90 hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)] cursor-pointer transition-all duration-150"
+						popoverContentClassName="min-w-80 max-w-9/10 overflow-hidden text-xs"
+						tooltip={tooltip}
 					/>
-				</PopoverContent>
-			)}
-		</Popover>
+				) : (
+					selectedProviderModels.length > 0 && (
+						<StandardTooltip content={tooltip}>
+							<div>
+								<Select
+									open={showSelect}
+									disabled={isStreaming}
+									value={selectedModelId === "custom-arn" ? "custom-arn" : selectedModelId}
+									onValueChange={(value) => {
+										setApiConfigurationField(
+											apiConfiguration.apiProvider === "costrict"
+												? "costrictModelId"
+												: "apiModelId",
+											value,
+										)
+
+										// Clear custom ARN if not using custom ARN option.
+										if (value !== "custom-arn" && selectedProvider === "bedrock") {
+											setApiConfigurationField("awsCustomArn", "")
+										}
+									}}
+									onOpenChange={(open) => {
+										setShowSelect(open)
+									}}>
+									<SelectTrigger
+										className={cn(
+											"rounded-md w-full h-6 px-1.5 opacity-90 hover:opacity-100 bg-vscode-input-background hover:border-[rgba(255,255,255,0.15)]",
+										)}
+										showIcon={false}>
+										<span className=" overflow-hidden text-ellipsis whitespace-nowrap">
+											<Brain className="inline-block mr-1" />
+											<SelectValue placeholder={t("settings:common.select")} />
+										</span>
+									</SelectTrigger>
+									<SelectContent className="min-w-80 max-w-9/10 overflow-hidden">
+										{selectedProviderModels.map((option) => (
+											<SelectItem key={option.value} value={option.value}>
+												{option.label}
+											</SelectItem>
+										))}
+										{selectedProvider === "bedrock" && (
+											<SelectItem value="custom-arn">
+												{t("settings:labels.useCustomArn")}
+											</SelectItem>
+										)}
+									</SelectContent>
+								</Select>
+							</div>
+						</StandardTooltip>
+					)
+				)}
+			</div>
+			{autoSwitchNotice &&
+				noticePortalContainer &&
+				createPortal(
+					<div
+						role="status"
+						className="fixed top-12 left-1/2 z-50 flex max-w-[90%] -translate-x-1/2 items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
+						<Info className="size-3.5 shrink-0" />
+						<span className="flex-1">
+							{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}
+						</span>
+						<X
+							className="size-3.5 shrink-0 cursor-pointer opacity-70 hover:opacity-100"
+							onClick={() => setAutoSwitchNotice(null)}
+						/>
+					</div>,
+					noticePortalContainer,
+				)}
+		</>
 	)
 }
 

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { ModelPicker } from "./ModelPicker"
 
 import {
@@ -18,11 +18,23 @@ import {
 import { useDebounce, useEvent } from "react-use"
 import { vscode } from "@/utils/vscode"
 import { convertHeadersToObject } from "./utils/headers"
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, StandardTooltip } from "@src/components/ui"
+import {
+	Select,
+	SelectTrigger,
+	SelectValue,
+	SelectContent,
+	SelectItem,
+	StandardTooltip,
+	Popover,
+	PopoverAnchor,
+	PopoverContent,
+} from "@src/components/ui"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { useSelectedModel } from "../ui/hooks/useSelectedModel"
-import { Brain } from "lucide-react"
+import { Brain, Info, X } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { getCorrectedCostrictModelId } from "./utils/correctModelSelection"
+import { useRooPortal } from "@/components/ui/hooks/useRooPortal"
 export interface ProviderRendererProps {
 	isEditMode?: boolean
 	isStreaming?: boolean
@@ -48,17 +60,118 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 }) => {
 	const [openAiModels, setOpenAiModels] = useState<Record<string, ModelInfo> | null>(null)
 
+	// Dedicated costrict model list — separate from openAiModels so a costrict refresh
+	// (incl. the unconditional login refresh) never overwrites the openai dropdown.
+	const [costrictModelList, setCostrictModelList] = useState<Record<string, ModelInfo> | null>(null)
+	const [isRefreshing, setIsRefreshing] = useState(false)
+	const [autoSwitchNotice, setAutoSwitchNotice] = useState<{ from: string; to: string } | null>(null)
+
+	// Last NON-EMPTY costrict server list; the "old list" baseline for correction.
+	const previousCostrictModelsRef = useRef<Record<string, ModelInfo> | null>(null)
+	// Mirrors apiConfiguration.costrictModelId; kept fresh by the effect below AND synchronously
+	// by the wrapped setter, so a just-typed custom model can't be mis-corrected by a racing refresh.
+	const selectedModelIdRef = useRef<string | undefined>(apiConfiguration.costrictModelId)
+	const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+	useEffect(() => {
+		selectedModelIdRef.current = apiConfiguration.costrictModelId
+	}, [apiConfiguration.costrictModelId])
+
+	// Wrapped setter: synchronously syncs the ref for costrictModelId before delegating.
+	const setApiConfigurationFieldWithRef = useCallback(
+		<K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => {
+			if (field === "costrictModelId") {
+				selectedModelIdRef.current = value as ProviderSettings["costrictModelId"]
+			}
+			setApiConfigurationField(field, value)
+		},
+		[setApiConfigurationField],
+	)
+	const setFieldRef = useRef(setApiConfigurationFieldWithRef)
+	useEffect(() => {
+		setFieldRef.current = setApiConfigurationFieldWithRef
+	}, [setApiConfigurationFieldWithRef])
+
+	// Container for the inline notice. Lives inside ChatView's hidden wrapper, so the notice
+	// escapes the toolbar's overflow-clip yet stays hidden when the chat tab is not active.
+	const noticePortalContainer = useRooPortal("costrict-portal")
+
+	// Auto-dismiss the inline notice after a few seconds.
+	useEffect(() => {
+		if (!autoSwitchNotice) {
+			return
+		}
+		const timer = setTimeout(() => setAutoSwitchNotice(null), 6000)
+		return () => clearTimeout(timer)
+	}, [autoSwitchNotice])
+
+	// Dismiss the notice once the user picks a different model than the one we corrected to.
+	useEffect(() => {
+		if (autoSwitchNotice && apiConfiguration.costrictModelId !== autoSwitchNotice.to) {
+			setAutoSwitchNotice(null)
+		}
+	}, [apiConfiguration.costrictModelId, autoSwitchNotice])
+
+	useEffect(() => {
+		return () => {
+			if (refreshTimeoutRef.current) {
+				clearTimeout(refreshTimeoutRef.current)
+			}
+		}
+	}, [])
+
+	const handleRefreshModels = useCallback(() => {
+		// Costrict round-trip: host flushes the cache, refetches, and pushes `costrictModels` back.
+		vscode.postMessage({ type: "flushRouterModels", text: "costrict" })
+		setIsRefreshing(true)
+		if (refreshTimeoutRef.current) {
+			clearTimeout(refreshTimeoutRef.current)
+		}
+		// Safety fallback: stop spinning even if no response arrives.
+		refreshTimeoutRef.current = setTimeout(() => setIsRefreshing(false), 10000)
+	}, [])
+
+	// Login refresh: ProviderRenderer is always mounted (ChatView is never unmounted), so it
+	// reliably catches the host's post-login `costrictLogined`. Fire unconditionally — refreshing
+	// the costrict list only touches `costrictModelList`, never the openai dropdown.
+	useEffect(() => {
+		const onLogined = (event: MessageEvent) => {
+			if (event.data?.type === "costrictLogined") {
+				handleRefreshModels()
+			}
+		}
+		window.addEventListener("message", onLogined)
+		return () => window.removeEventListener("message", onLogined)
+	}, [handleRefreshModels])
+
 	const onMessage = useCallback((event: MessageEvent) => {
 		const message: ExtensionMessage = event.data
 
 		switch (message.type) {
 			case "costrictModels": {
 				const { fullResponseData = [] } = message
-				setOpenAiModels(
-					Object.fromEntries(
-						fullResponseData.map((item) => [item.id, { ...(item ?? costrictModels.default) }]),
-					),
-				)
+				const newModels = Object.fromEntries(
+					fullResponseData.map((item) => [item.id, { ...(item ?? costrictModels.default) }]),
+				) as Record<string, ModelInfo>
+				const newModelIds = Object.keys(newModels)
+
+				// Selection correction: compare against the dedicated costrict baseline.
+				// The pure rule (and its rationale) lives in ./utils/correctModelSelection.
+				const oldModelIds = Object.keys(previousCostrictModelsRef.current ?? {})
+				const selectedModelId = selectedModelIdRef.current
+				const corrected = getCorrectedCostrictModelId(oldModelIds, newModelIds, selectedModelId)
+				if (corrected && selectedModelId) {
+					setFieldRef.current("costrictModelId", corrected)
+					setAutoSwitchNotice({ from: selectedModelId, to: corrected })
+				}
+
+				// Preserve the last NON-EMPTY costrict list as the baseline for the next refresh.
+				if (newModelIds.length > 0) {
+					previousCostrictModelsRef.current = newModels
+				}
+
+				setCostrictModelList(newModels)
+				setIsRefreshing(false)
 				break
 			}
 			case "openAiModels": {
@@ -160,7 +273,7 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 				serviceName: "costrict",
 				defaultModelId: apiConfiguration.costrictModelId || costrictDefaultModelId,
 				serviceUrl: apiConfiguration.costrictBaseUrl?.trim() || (window as any).COSTRICT_BASE_URL,
-				models: openAiModels ?? {},
+				models: costrictModelList ?? {},
 			},
 			openrouter: {
 				modelIdKey: "openRouterModelId",
@@ -198,7 +311,13 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 				models: routerModels?.litellm ?? {},
 			},
 		}),
-		[apiConfiguration.costrictModelId, apiConfiguration.costrictBaseUrl, openAiModels, routerModels],
+		[
+			apiConfiguration.costrictModelId,
+			apiConfiguration.costrictBaseUrl,
+			costrictModelList,
+			openAiModels,
+			routerModels,
+		],
 	)
 
 	const config = providerConfig[selectedProvider as keyof typeof providerConfig] || {}
@@ -216,74 +335,101 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			? `${t("settings:modelPicker.label")}: ${defaultModelId}`
 			: t("chat:selectModel")
 	return (
-		<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
-			{config?.modelIdKey ? (
-				<ModelPicker
-					isChatBox={true}
-					modelPickerId={isEditMode ? "modelPickerEdit" : "modelPicker"}
-					apiConfiguration={apiConfiguration}
-					setApiConfigurationField={setApiConfigurationField}
-					defaultModelId={defaultModelId}
-					models={config?.models ?? {}}
-					modelIdKey={config.modelIdKey as any}
-					serviceName={config.serviceName}
-					serviceUrl={config.serviceUrl}
-					organizationAllowList={organizationAllowList}
-					showInfoView={false}
-					showLabel={false}
-					isStreaming={isStreaming}
-					triggerClassName="rounded-md max-w-80 px-[6px] text-xs h-6 opacity-90 hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)] cursor-pointer transition-all duration-150"
-					popoverContentClassName="min-w-80 max-w-9/10 overflow-hidden text-xs"
-					tooltip={tooltip}
-				/>
-			) : (
-				selectedProviderModels.length > 0 && (
-					<StandardTooltip content={tooltip}>
-						<div>
-							<Select
-								open={showSelect}
-								disabled={isStreaming}
-								value={selectedModelId === "custom-arn" ? "custom-arn" : selectedModelId}
-								onValueChange={(value) => {
-									setApiConfigurationField(
-										apiConfiguration.apiProvider === "costrict" ? "costrictModelId" : "apiModelId",
-										value,
-									)
+		<Popover open={!!autoSwitchNotice} onOpenChange={(o) => !o && setAutoSwitchNotice(null)}>
+			<PopoverAnchor asChild>
+				<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
+					{config?.modelIdKey ? (
+						<ModelPicker
+							isChatBox={true}
+							modelPickerId={isEditMode ? "modelPickerEdit" : "modelPicker"}
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationFieldWithRef}
+							defaultModelId={defaultModelId}
+							models={config?.models ?? {}}
+							modelIdKey={config.modelIdKey as any}
+							serviceName={config.serviceName}
+							serviceUrl={config.serviceUrl}
+							organizationAllowList={organizationAllowList}
+							showInfoView={false}
+							showLabel={false}
+							isStreaming={isStreaming}
+							onRefreshModels={selectedProvider === "costrict" ? handleRefreshModels : undefined}
+							isRefreshingModels={isRefreshing}
+							triggerClassName="rounded-md max-w-80 px-[6px] text-xs h-6 opacity-90 hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)] cursor-pointer transition-all duration-150"
+							popoverContentClassName="min-w-80 max-w-9/10 overflow-hidden text-xs"
+							tooltip={tooltip}
+						/>
+					) : (
+						selectedProviderModels.length > 0 && (
+							<StandardTooltip content={tooltip}>
+								<div>
+									<Select
+										open={showSelect}
+										disabled={isStreaming}
+										value={selectedModelId === "custom-arn" ? "custom-arn" : selectedModelId}
+										onValueChange={(value) => {
+											setApiConfigurationField(
+												apiConfiguration.apiProvider === "costrict"
+													? "costrictModelId"
+													: "apiModelId",
+												value,
+											)
 
-									// Clear custom ARN if not using custom ARN option.
-									if (value !== "custom-arn" && selectedProvider === "bedrock") {
-										setApiConfigurationField("awsCustomArn", "")
-									}
-								}}
-								onOpenChange={(open) => {
-									setShowSelect(open)
-								}}>
-								<SelectTrigger
-									className={cn(
-										"rounded-md w-full h-6 px-1.5 opacity-90 hover:opacity-100 bg-vscode-input-background hover:border-[rgba(255,255,255,0.15)]",
-									)}
-									showIcon={false}>
-									<span className=" overflow-hidden text-ellipsis whitespace-nowrap">
-										<Brain className="inline-block mr-1" />
-										<SelectValue placeholder={t("settings:common.select")} />
-									</span>
-								</SelectTrigger>
-								<SelectContent className="min-w-80 max-w-9/10 overflow-hidden">
-									{selectedProviderModels.map((option) => (
-										<SelectItem key={option.value} value={option.value}>
-											{option.label}
-										</SelectItem>
-									))}
-									{selectedProvider === "bedrock" && (
-										<SelectItem value="custom-arn">{t("settings:labels.useCustomArn")}</SelectItem>
-									)}
-								</SelectContent>
-							</Select>
-						</div>
-					</StandardTooltip>
-				)
+											// Clear custom ARN if not using custom ARN option.
+											if (value !== "custom-arn" && selectedProvider === "bedrock") {
+												setApiConfigurationField("awsCustomArn", "")
+											}
+										}}
+										onOpenChange={(open) => {
+											setShowSelect(open)
+										}}>
+										<SelectTrigger
+											className={cn(
+												"rounded-md w-full h-6 px-1.5 opacity-90 hover:opacity-100 bg-vscode-input-background hover:border-[rgba(255,255,255,0.15)]",
+											)}
+											showIcon={false}>
+											<span className=" overflow-hidden text-ellipsis whitespace-nowrap">
+												<Brain className="inline-block mr-1" />
+												<SelectValue placeholder={t("settings:common.select")} />
+											</span>
+										</SelectTrigger>
+										<SelectContent className="min-w-80 max-w-9/10 overflow-hidden">
+											{selectedProviderModels.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
+											{selectedProvider === "bedrock" && (
+												<SelectItem value="custom-arn">
+													{t("settings:labels.useCustomArn")}
+												</SelectItem>
+											)}
+										</SelectContent>
+									</Select>
+								</div>
+							</StandardTooltip>
+						)
+					)}
+				</div>
+			</PopoverAnchor>
+			{autoSwitchNotice && noticePortalContainer && (
+				<PopoverContent
+					container={noticePortalContainer}
+					side="top"
+					align="start"
+					onOpenAutoFocus={(e) => e.preventDefault()}
+					className="z-50 flex w-auto max-w-80 items-center gap-1 whitespace-normal rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-2 py-1 text-xs text-vscode-descriptionForeground shadow">
+					<Info className="size-3 shrink-0" />
+					<span className="flex-1">
+						{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}
+					</span>
+					<X
+						className="size-3 shrink-0 cursor-pointer opacity-70 hover:opacity-100"
+						onClick={() => setAutoSwitchNotice(null)}
+					/>
+				</PopoverContent>
 			)}
-		</div>
+		</Popover>
 	)
 }
 

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -66,6 +66,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	// Becomes true once apiConfiguration has actually caught up to the corrected model id.
 	// Guards the "dismiss on user re-pick" effect against firing during the async config round-trip.
 	const noticeSettledRef = useRef(false)
+	// Anchor the notice just above the model selector chip (computed from its bounding rect).
+	const anchorRef = useRef<HTMLDivElement>(null)
+	const [noticePos, setNoticePos] = useState<{ left: number; bottom: number } | null>(null)
 
 	useEffect(() => {
 		selectedModelIdRef.current = apiConfiguration.costrictModelId
@@ -97,6 +100,20 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 		}
 		const timer = setTimeout(() => setAutoSwitchNotice(null), 6000)
 		return () => clearTimeout(timer)
+	}, [autoSwitchNotice])
+
+	// Position the notice just above the model selector chip when it appears.
+	useEffect(() => {
+		if (!autoSwitchNotice) {
+			setNoticePos(null)
+			return
+		}
+		const el = anchorRef.current
+		if (!el) {
+			return
+		}
+		const rect = el.getBoundingClientRect()
+		setNoticePos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 })
 	}, [autoSwitchNotice])
 
 	// Dismiss the notice once the user picks a different model than the one we corrected to.
@@ -340,7 +357,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			: t("chat:selectModel")
 	return (
 		<>
-			<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
+			<div
+				ref={anchorRef}
+				className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
 				{config?.modelIdKey ? (
 					<ModelPicker
 						isChatBox={true}
@@ -416,12 +435,14 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			</div>
 			{autoSwitchNotice &&
 				noticePortalContainer &&
+				noticePos &&
 				createPortal(
 					<div
 						role="status"
-						className="fixed top-12 left-1/2 z-50 flex max-w-[90%] -translate-x-1/2 items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
+						style={{ position: "fixed", left: noticePos.left, bottom: noticePos.bottom, zIndex: 50 }}
+						className="flex max-w-80 items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
 						<Info className="size-3.5 shrink-0" />
-						<span className="flex-1">
+						<span className="flex-1 whitespace-normal">
 							{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}
 						</span>
 						<X

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -419,7 +419,7 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 				createPortal(
 					<div
 						role="status"
-						className="fixed bottom-14 left-3 z-50 flex max-w-[80%] items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
+						className="fixed bottom-14 left-3 z-[3000] flex max-w-[80%] items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
 						<Info className="size-3.5 shrink-0" />
 						<span className="flex-1 whitespace-normal">
 							{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -66,9 +66,6 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	// Becomes true once apiConfiguration has actually caught up to the corrected model id.
 	// Guards the "dismiss on user re-pick" effect against firing during the async config round-trip.
 	const noticeSettledRef = useRef(false)
-	// Anchor the notice just above the model selector chip (computed from its bounding rect).
-	const anchorRef = useRef<HTMLDivElement>(null)
-	const [noticePos, setNoticePos] = useState<{ left: number; bottom: number } | null>(null)
 
 	useEffect(() => {
 		selectedModelIdRef.current = apiConfiguration.costrictModelId
@@ -100,20 +97,6 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 		}
 		const timer = setTimeout(() => setAutoSwitchNotice(null), 6000)
 		return () => clearTimeout(timer)
-	}, [autoSwitchNotice])
-
-	// Position the notice just above the model selector chip when it appears.
-	useEffect(() => {
-		if (!autoSwitchNotice) {
-			setNoticePos(null)
-			return
-		}
-		const el = anchorRef.current
-		if (!el) {
-			return
-		}
-		const rect = el.getBoundingClientRect()
-		setNoticePos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 })
 	}, [autoSwitchNotice])
 
 	// Dismiss the notice once the user picks a different model than the one we corrected to.
@@ -357,9 +340,7 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			: t("chat:selectModel")
 	return (
 		<>
-			<div
-				ref={anchorRef}
-				className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
+			<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
 				{config?.modelIdKey ? (
 					<ModelPicker
 						isChatBox={true}
@@ -435,12 +416,10 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			</div>
 			{autoSwitchNotice &&
 				noticePortalContainer &&
-				noticePos &&
 				createPortal(
 					<div
 						role="status"
-						style={{ position: "fixed", left: noticePos.left, bottom: noticePos.bottom, zIndex: 50 }}
-						className="flex max-w-80 items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
+						className="fixed bottom-14 left-3 z-50 flex max-w-[80%] items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
 						<Info className="size-3.5 shrink-0" />
 						<span className="flex-1 whitespace-normal">
 							{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { createPortal } from "react-dom"
 import { ModelPicker } from "./ModelPicker"
 
 import {
@@ -22,7 +21,7 @@ import { convertHeadersToObject } from "./utils/headers"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, StandardTooltip } from "@src/components/ui"
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { useSelectedModel } from "../ui/hooks/useSelectedModel"
-import { Brain, Info, X } from "lucide-react"
+import { Brain } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getCorrectedCostrictModelId } from "./utils/correctModelSelection"
 export interface ProviderRendererProps {
@@ -48,30 +47,25 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	routerModels,
 	selectedProviderModels,
 }) => {
+	const { t } = useAppTranslation()
+
 	const [openAiModels, setOpenAiModels] = useState<Record<string, ModelInfo> | null>(null)
 
 	// Dedicated costrict model list — separate from openAiModels so a costrict refresh
-	// (incl. the unconditional login refresh) never overwrites the openai dropdown.
+	// (incl. the login refresh) never overwrites the openai dropdown.
 	const [costrictModelList, setCostrictModelList] = useState<Record<string, ModelInfo> | null>(null)
 	const [isRefreshing, setIsRefreshing] = useState(false)
-	const [autoSwitchNotice, setAutoSwitchNotice] = useState<{ from: string; to: string } | null>(null)
 
 	// Last NON-EMPTY costrict server list; the "old list" baseline for correction.
 	const previousCostrictModelsRef = useRef<Record<string, ModelInfo> | null>(null)
 	// Mirrors apiConfiguration.costrictModelId; kept fresh by the effect below AND synchronously
 	// by the wrapped setter, so a just-typed custom model can't be mis-corrected by a racing refresh.
 	const selectedModelIdRef = useRef<string | undefined>(apiConfiguration.costrictModelId)
-	// Mirror props that the stable onMessage callback / listeners must read without re-subscribing.
+	// Mirror props/translation the stable onMessage callback / listeners read without re-subscribing.
 	const isEditModeRef = useRef(isEditMode)
 	const selectedProviderRef = useRef(selectedProvider)
+	const tRef = useRef(t)
 	const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-	// Becomes true once apiConfiguration has actually caught up to the corrected model id.
-	// Guards the "dismiss on user re-pick" effect against firing during the async config round-trip.
-	const noticeSettledRef = useRef(false)
-	// Anchor the notice just above this model selector chip (computed from its bounding rect),
-	// so it tracks the selector wherever the panel/toolbar is laid out.
-	const anchorRef = useRef<HTMLDivElement>(null)
-	const [noticePos, setNoticePos] = useState<{ left: number; bottom: number } | null>(null)
 
 	useEffect(() => {
 		selectedModelIdRef.current = apiConfiguration.costrictModelId
@@ -84,6 +78,10 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	useEffect(() => {
 		selectedProviderRef.current = selectedProvider
 	}, [selectedProvider])
+
+	useEffect(() => {
+		tRef.current = t
+	}, [t])
 
 	// Wrapped setter: synchronously syncs the ref for costrictModelId before delegating.
 	const setApiConfigurationFieldWithRef = useCallback(
@@ -99,57 +97,6 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	useEffect(() => {
 		setFieldRef.current = setApiConfigurationFieldWithRef
 	}, [setApiConfigurationFieldWithRef])
-
-	// Auto-dismiss the inline notice after a few seconds.
-	useEffect(() => {
-		if (!autoSwitchNotice) {
-			return
-		}
-		const timer = setTimeout(() => setAutoSwitchNotice(null), 6000)
-		return () => clearTimeout(timer)
-	}, [autoSwitchNotice])
-
-	// Compute the notice position from the model selector's rect when it appears, and keep it in
-	// sync on resize/scroll (fixed coords detach from layout once set). The rect.width === 0 guard
-	// also prevents rendering when the chat tab is hidden (anchor is display:none → zero rect).
-	useEffect(() => {
-		if (!autoSwitchNotice) {
-			setNoticePos(null)
-			return
-		}
-		const computeNoticePos = () => {
-			const rect = anchorRef.current?.getBoundingClientRect()
-			if (!rect || rect.width === 0) {
-				setNoticePos(null)
-				return
-			}
-			setNoticePos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 })
-		}
-		computeNoticePos()
-		window.addEventListener("resize", computeNoticePos)
-		window.addEventListener("scroll", computeNoticePos, true)
-		return () => {
-			window.removeEventListener("resize", computeNoticePos)
-			window.removeEventListener("scroll", computeNoticePos, true)
-		}
-	}, [autoSwitchNotice])
-
-	// Dismiss the notice once the user picks a different model than the one we corrected to.
-	// We must first wait for apiConfiguration to "settle" to the corrected id — the correction
-	// updates the config asynchronously (round-trip via upsertApiConfiguration), so right after
-	// the notice is set the prop still holds the OLD id, which must NOT count as a user re-pick.
-	useEffect(() => {
-		if (!autoSwitchNotice) {
-			noticeSettledRef.current = false
-			return
-		}
-		if (apiConfiguration.costrictModelId === autoSwitchNotice.to) {
-			noticeSettledRef.current = true
-		} else if (noticeSettledRef.current) {
-			// Config had reached the corrected id and has now changed again → genuine user re-pick.
-			setAutoSwitchNotice(null)
-		}
-	}, [apiConfiguration.costrictModelId, autoSwitchNotice])
 
 	useEffect(() => {
 		return () => {
@@ -172,12 +119,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 
 	// Login refresh: ProviderRenderer is always mounted (ChatView is never unmounted), so it
 	// reliably catches the host's post-login `costrictLogined`. Only the primary (non-edit)
-	// instance flushes; refreshing the costrict list only touches `costrictModelList`, and the
-	// host only pushes `costrictModels` back when on the costrict provider, so this is safe.
+	// instance flushes; the host only pushes `costrictModels` back when on the costrict provider.
 	useEffect(() => {
 		const onLogined = (event: MessageEvent) => {
-			// Only the primary (non-edit) instance drives the login refresh, to avoid a duplicate
-			// flush from the message-edit ChatTextArea instance.
 			if (event.data?.type === "costrictLogined" && !isEditMode) {
 				handleRefreshModels()
 			}
@@ -212,7 +156,15 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 					selectedProviderRef.current === "costrict"
 				) {
 					setFieldRef.current("costrictModelId", corrected)
-					setAutoSwitchNotice({ from: selectedModelId, to: corrected })
+					// Notify via the standard CoStrict provider tip (native VS Code notification),
+					// matching the existing tip UX instead of a custom in-dialog toast.
+					vscode.postMessage({
+						type: "costrictProviderTip",
+						values: {
+							tipType: "info",
+							msg: tRef.current("chat:modelAutoSwitched", { from: selectedModelId, to: corrected }),
+						},
+					})
 				}
 
 				// Preserve the last NON-EMPTY costrict list as the baseline for the next refresh.
@@ -254,9 +206,6 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			// check messsage type only close with action
 			if (event.data && event.data.type === "action") {
 				setShowSelect(false)
-				// Tab/page navigation: dismiss the auto-switch notice so a body-portal toast
-				// can't linger over another tab.
-				setAutoSwitchNotice(null)
 			}
 		}
 		window.addEventListener("message", handlePageChange)
@@ -375,8 +324,6 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 
 	const config = providerConfig[selectedProvider as keyof typeof providerConfig] || {}
 
-	const { t } = useAppTranslation()
-
 	const { id: selectedModelId } = useSelectedModel(apiConfiguration)
 	const defaultModelId =
 		(apiConfiguration.apiProvider === "costrict"
@@ -388,104 +335,76 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			? `${t("settings:modelPicker.label")}: ${defaultModelId}`
 			: t("chat:selectModel")
 	return (
-		<>
-			<div
-				ref={anchorRef}
-				className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
-				{config?.modelIdKey ? (
-					<ModelPicker
-						isChatBox={true}
-						modelPickerId={isEditMode ? "modelPickerEdit" : "modelPicker"}
-						apiConfiguration={apiConfiguration}
-						setApiConfigurationField={setApiConfigurationFieldWithRef}
-						defaultModelId={defaultModelId}
-						models={config?.models ?? {}}
-						modelIdKey={config.modelIdKey as any}
-						serviceName={config.serviceName}
-						serviceUrl={config.serviceUrl}
-						organizationAllowList={organizationAllowList}
-						showInfoView={false}
-						showLabel={false}
-						isStreaming={isStreaming}
-						onRefreshModels={
-							!isEditMode && selectedProvider === "costrict" ? handleRefreshModels : undefined
-						}
-						isRefreshingModels={isRefreshing}
-						triggerClassName="rounded-md max-w-80 px-[6px] text-xs h-6 opacity-90 hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)] cursor-pointer transition-all duration-150"
-						popoverContentClassName="min-w-80 max-w-9/10 overflow-hidden text-xs"
-						tooltip={tooltip}
-					/>
-				) : (
-					selectedProviderModels.length > 0 && (
-						<StandardTooltip content={tooltip}>
-							<div>
-								<Select
-									open={showSelect}
-									disabled={isStreaming}
-									value={selectedModelId === "custom-arn" ? "custom-arn" : selectedModelId}
-									onValueChange={(value) => {
-										setApiConfigurationField(
-											apiConfiguration.apiProvider === "costrict"
-												? "costrictModelId"
-												: "apiModelId",
-											value,
-										)
+		<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
+			{config?.modelIdKey ? (
+				<ModelPicker
+					isChatBox={true}
+					modelPickerId={isEditMode ? "modelPickerEdit" : "modelPicker"}
+					apiConfiguration={apiConfiguration}
+					setApiConfigurationField={setApiConfigurationFieldWithRef}
+					defaultModelId={defaultModelId}
+					models={config?.models ?? {}}
+					modelIdKey={config.modelIdKey as any}
+					serviceName={config.serviceName}
+					serviceUrl={config.serviceUrl}
+					organizationAllowList={organizationAllowList}
+					showInfoView={false}
+					showLabel={false}
+					isStreaming={isStreaming}
+					onRefreshModels={!isEditMode && selectedProvider === "costrict" ? handleRefreshModels : undefined}
+					isRefreshingModels={isRefreshing}
+					triggerClassName="rounded-md max-w-80 px-[6px] text-xs h-6 opacity-90 hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)] cursor-pointer transition-all duration-150"
+					popoverContentClassName="min-w-80 max-w-9/10 overflow-hidden text-xs"
+					tooltip={tooltip}
+				/>
+			) : (
+				selectedProviderModels.length > 0 && (
+					<StandardTooltip content={tooltip}>
+						<div>
+							<Select
+								open={showSelect}
+								disabled={isStreaming}
+								value={selectedModelId === "custom-arn" ? "custom-arn" : selectedModelId}
+								onValueChange={(value) => {
+									setApiConfigurationField(
+										apiConfiguration.apiProvider === "costrict" ? "costrictModelId" : "apiModelId",
+										value,
+									)
 
-										// Clear custom ARN if not using custom ARN option.
-										if (value !== "custom-arn" && selectedProvider === "bedrock") {
-											setApiConfigurationField("awsCustomArn", "")
-										}
-									}}
-									onOpenChange={(open) => {
-										setShowSelect(open)
-									}}>
-									<SelectTrigger
-										className={cn(
-											"rounded-md w-full h-6 px-1.5 opacity-90 hover:opacity-100 bg-vscode-input-background hover:border-[rgba(255,255,255,0.15)]",
-										)}
-										showIcon={false}>
-										<span className=" overflow-hidden text-ellipsis whitespace-nowrap">
-											<Brain className="inline-block mr-1" />
-											<SelectValue placeholder={t("settings:common.select")} />
-										</span>
-									</SelectTrigger>
-									<SelectContent className="min-w-80 max-w-9/10 overflow-hidden">
-										{selectedProviderModels.map((option) => (
-											<SelectItem key={option.value} value={option.value}>
-												{option.label}
-											</SelectItem>
-										))}
-										{selectedProvider === "bedrock" && (
-											<SelectItem value="custom-arn">
-												{t("settings:labels.useCustomArn")}
-											</SelectItem>
-										)}
-									</SelectContent>
-								</Select>
-							</div>
-						</StandardTooltip>
-					)
-				)}
-			</div>
-			{autoSwitchNotice &&
-				noticePos &&
-				createPortal(
-					<div
-						role="status"
-						style={{ position: "fixed", left: noticePos.left, bottom: noticePos.bottom, zIndex: 3000 }}
-						className="flex max-w-80 items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
-						<Info className="size-3.5 shrink-0" />
-						<span className="flex-1 whitespace-normal">
-							{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}
-						</span>
-						<X
-							className="size-3.5 shrink-0 cursor-pointer opacity-70 hover:opacity-100"
-							onClick={() => setAutoSwitchNotice(null)}
-						/>
-					</div>,
-					document.body,
-				)}
-		</>
+									// Clear custom ARN if not using custom ARN option.
+									if (value !== "custom-arn" && selectedProvider === "bedrock") {
+										setApiConfigurationField("awsCustomArn", "")
+									}
+								}}
+								onOpenChange={(open) => {
+									setShowSelect(open)
+								}}>
+								<SelectTrigger
+									className={cn(
+										"rounded-md w-full h-6 px-1.5 opacity-90 hover:opacity-100 bg-vscode-input-background hover:border-[rgba(255,255,255,0.15)]",
+									)}
+									showIcon={false}>
+									<span className=" overflow-hidden text-ellipsis whitespace-nowrap">
+										<Brain className="inline-block mr-1" />
+										<SelectValue placeholder={t("settings:common.select")} />
+									</span>
+								</SelectTrigger>
+								<SelectContent className="min-w-80 max-w-9/10 overflow-hidden">
+									{selectedProviderModels.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+									{selectedProvider === "bedrock" && (
+										<SelectItem value="custom-arn">{t("settings:labels.useCustomArn")}</SelectItem>
+									)}
+								</SelectContent>
+							</Select>
+						</div>
+					</StandardTooltip>
+				)
+			)}
+		</div>
 	)
 }
 

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -61,6 +61,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	// Mirrors apiConfiguration.costrictModelId; kept fresh by the effect below AND synchronously
 	// by the wrapped setter, so a just-typed custom model can't be mis-corrected by a racing refresh.
 	const selectedModelIdRef = useRef<string | undefined>(apiConfiguration.costrictModelId)
+	// Mirror props that the stable onMessage callback / listeners must read without re-subscribing.
+	const isEditModeRef = useRef(isEditMode)
+	const selectedProviderRef = useRef(selectedProvider)
 	const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 	// Becomes true once apiConfiguration has actually caught up to the corrected model id.
 	// Guards the "dismiss on user re-pick" effect against firing during the async config round-trip.
@@ -73,6 +76,14 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	useEffect(() => {
 		selectedModelIdRef.current = apiConfiguration.costrictModelId
 	}, [apiConfiguration.costrictModelId])
+
+	useEffect(() => {
+		isEditModeRef.current = isEditMode
+	}, [isEditMode])
+
+	useEffect(() => {
+		selectedProviderRef.current = selectedProvider
+	}, [selectedProvider])
 
 	// Wrapped setter: synchronously syncs the ref for costrictModelId before delegating.
 	const setApiConfigurationFieldWithRef = useCallback(
@@ -98,19 +109,29 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 		return () => clearTimeout(timer)
 	}, [autoSwitchNotice])
 
-	// Compute the notice position from the model selector's rect when it appears.
+	// Compute the notice position from the model selector's rect when it appears, and keep it in
+	// sync on resize/scroll (fixed coords detach from layout once set). The rect.width === 0 guard
+	// also prevents rendering when the chat tab is hidden (anchor is display:none → zero rect).
 	useEffect(() => {
 		if (!autoSwitchNotice) {
 			setNoticePos(null)
 			return
 		}
-		const rect = anchorRef.current?.getBoundingClientRect()
-		if (!rect || rect.width === 0) {
-			// Anchor not laid out (e.g. a hidden duplicate instance) — don't show this one.
-			setNoticePos(null)
-			return
+		const computeNoticePos = () => {
+			const rect = anchorRef.current?.getBoundingClientRect()
+			if (!rect || rect.width === 0) {
+				setNoticePos(null)
+				return
+			}
+			setNoticePos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 })
 		}
-		setNoticePos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 })
+		computeNoticePos()
+		window.addEventListener("resize", computeNoticePos)
+		window.addEventListener("scroll", computeNoticePos, true)
+		return () => {
+			window.removeEventListener("resize", computeNoticePos)
+			window.removeEventListener("scroll", computeNoticePos, true)
+		}
 	}, [autoSwitchNotice])
 
 	// Dismiss the notice once the user picks a different model than the one we corrected to.
@@ -154,13 +175,15 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	// the costrict list only touches `costrictModelList`, never the openai dropdown.
 	useEffect(() => {
 		const onLogined = (event: MessageEvent) => {
-			if (event.data?.type === "costrictLogined") {
+			// Only the primary (non-edit) instance drives the login refresh, to avoid a duplicate
+			// flush from the message-edit ChatTextArea instance.
+			if (event.data?.type === "costrictLogined" && !isEditMode) {
 				handleRefreshModels()
 			}
 		}
 		window.addEventListener("message", onLogined)
 		return () => window.removeEventListener("message", onLogined)
-	}, [handleRefreshModels])
+	}, [handleRefreshModels, isEditMode])
 
 	const onMessage = useCallback((event: MessageEvent) => {
 		const message: ExtensionMessage = event.data
@@ -178,7 +201,15 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 				const oldModelIds = Object.keys(previousCostrictModelsRef.current ?? {})
 				const selectedModelId = selectedModelIdRef.current
 				const corrected = getCorrectedCostrictModelId(oldModelIds, newModelIds, selectedModelId)
-				if (corrected && selectedModelId) {
+				// Only the primary costrict selector applies the correction + notice. Other providers
+				// also receive costrictModels pushes (requestRouterModels broadcasts them), and the
+				// message-edit duplicate instance must not fire these global side-effects.
+				if (
+					corrected &&
+					selectedModelId &&
+					!isEditModeRef.current &&
+					selectedProviderRef.current === "costrict"
+				) {
 					setFieldRef.current("costrictModelId", corrected)
 					setAutoSwitchNotice({ from: selectedModelId, to: corrected })
 				}
@@ -222,6 +253,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			// check messsage type only close with action
 			if (event.data && event.data.type === "action") {
 				setShowSelect(false)
+				// Tab/page navigation: dismiss the auto-switch notice so a body-portal toast
+				// can't linger over another tab.
+				setAutoSwitchNotice(null)
 			}
 		}
 		window.addEventListener("message", handlePageChange)
@@ -372,7 +406,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 						showInfoView={false}
 						showLabel={false}
 						isStreaming={isStreaming}
-						onRefreshModels={selectedProvider === "costrict" ? handleRefreshModels : undefined}
+						onRefreshModels={
+							!isEditMode && selectedProvider === "costrict" ? handleRefreshModels : undefined
+						}
 						isRefreshingModels={isRefreshing}
 						triggerClassName="rounded-md max-w-80 px-[6px] text-xs h-6 opacity-90 hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)] hover:border-[rgba(255,255,255,0.15)] cursor-pointer transition-all duration-150"
 						popoverContentClassName="min-w-80 max-w-9/10 overflow-hidden text-xs"

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -65,6 +65,10 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	// Becomes true once apiConfiguration has actually caught up to the corrected model id.
 	// Guards the "dismiss on user re-pick" effect against firing during the async config round-trip.
 	const noticeSettledRef = useRef(false)
+	// Anchor the notice just above this model selector chip (computed from its bounding rect),
+	// so it tracks the selector wherever the panel/toolbar is laid out.
+	const anchorRef = useRef<HTMLDivElement>(null)
+	const [noticePos, setNoticePos] = useState<{ left: number; bottom: number } | null>(null)
 
 	useEffect(() => {
 		selectedModelIdRef.current = apiConfiguration.costrictModelId
@@ -92,6 +96,21 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 		}
 		const timer = setTimeout(() => setAutoSwitchNotice(null), 6000)
 		return () => clearTimeout(timer)
+	}, [autoSwitchNotice])
+
+	// Compute the notice position from the model selector's rect when it appears.
+	useEffect(() => {
+		if (!autoSwitchNotice) {
+			setNoticePos(null)
+			return
+		}
+		const rect = anchorRef.current?.getBoundingClientRect()
+		if (!rect || rect.width === 0) {
+			// Anchor not laid out (e.g. a hidden duplicate instance) — don't show this one.
+			setNoticePos(null)
+			return
+		}
+		setNoticePos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 })
 	}, [autoSwitchNotice])
 
 	// Dismiss the notice once the user picks a different model than the one we corrected to.
@@ -335,7 +354,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 			: t("chat:selectModel")
 	return (
 		<>
-			<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
+			<div
+				ref={anchorRef}
+				className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
 				{config?.modelIdKey ? (
 					<ModelPicker
 						isChatBox={true}
@@ -410,10 +431,12 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 				)}
 			</div>
 			{autoSwitchNotice &&
+				noticePos &&
 				createPortal(
 					<div
 						role="status"
-						className="fixed bottom-14 left-3 z-[3000] flex max-w-[80%] items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
+						style={{ position: "fixed", left: noticePos.left, bottom: noticePos.bottom, zIndex: 3000 }}
+						className="flex max-w-80 items-center gap-2 rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-3 py-2 text-xs text-vscode-foreground shadow-lg">
 						<Info className="size-3.5 shrink-0" />
 						<span className="flex-1 whitespace-normal">
 							{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -72,6 +72,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	// by the wrapped setter, so a just-typed custom model can't be mis-corrected by a racing refresh.
 	const selectedModelIdRef = useRef<string | undefined>(apiConfiguration.costrictModelId)
 	const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	// Becomes true once apiConfiguration has actually caught up to the corrected model id.
+	// Guards the "dismiss on user re-pick" effect against firing during the async config round-trip.
+	const noticeSettledRef = useRef(false)
 
 	useEffect(() => {
 		selectedModelIdRef.current = apiConfiguration.costrictModelId
@@ -106,8 +109,18 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	}, [autoSwitchNotice])
 
 	// Dismiss the notice once the user picks a different model than the one we corrected to.
+	// We must first wait for apiConfiguration to "settle" to the corrected id — the correction
+	// updates the config asynchronously (round-trip via upsertApiConfiguration), so right after
+	// the notice is set the prop still holds the OLD id, which must NOT count as a user re-pick.
 	useEffect(() => {
-		if (autoSwitchNotice && apiConfiguration.costrictModelId !== autoSwitchNotice.to) {
+		if (!autoSwitchNotice) {
+			noticeSettledRef.current = false
+			return
+		}
+		if (apiConfiguration.costrictModelId === autoSwitchNotice.to) {
+			noticeSettledRef.current = true
+		} else if (noticeSettledRef.current) {
+			// Config had reached the corrected id and has now changed again → genuine user re-pick.
 			setAutoSwitchNotice(null)
 		}
 	}, [apiConfiguration.costrictModelId, autoSwitchNotice])

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -171,8 +171,9 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	}, [])
 
 	// Login refresh: ProviderRenderer is always mounted (ChatView is never unmounted), so it
-	// reliably catches the host's post-login `costrictLogined`. Fire unconditionally — refreshing
-	// the costrict list only touches `costrictModelList`, never the openai dropdown.
+	// reliably catches the host's post-login `costrictLogined`. Only the primary (non-edit)
+	// instance flushes; refreshing the costrict list only touches `costrictModelList`, and the
+	// host only pushes `costrictModels` back when on the costrict provider, so this is safe.
 	useEffect(() => {
 		const onLogined = (event: MessageEvent) => {
 			// Only the primary (non-edit) instance drives the login refresh, to avoid a duplicate

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -25,7 +25,6 @@ import { useSelectedModel } from "../ui/hooks/useSelectedModel"
 import { Brain, Info, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getCorrectedCostrictModelId } from "./utils/correctModelSelection"
-import { useRooPortal } from "@/components/ui/hooks/useRooPortal"
 export interface ProviderRendererProps {
 	isEditMode?: boolean
 	isStreaming?: boolean
@@ -85,10 +84,6 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 	useEffect(() => {
 		setFieldRef.current = setApiConfigurationFieldWithRef
 	}, [setApiConfigurationFieldWithRef])
-
-	// Container for the inline notice. Lives inside ChatView's hidden wrapper, so the notice
-	// escapes the toolbar's overflow-clip yet stays hidden when the chat tab is not active.
-	const noticePortalContainer = useRooPortal("costrict-portal")
 
 	// Auto-dismiss the inline notice after a few seconds.
 	useEffect(() => {
@@ -415,7 +410,6 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 				)}
 			</div>
 			{autoSwitchNotice &&
-				noticePortalContainer &&
 				createPortal(
 					<div
 						role="status"
@@ -429,7 +423,7 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 							onClick={() => setAutoSwitchNotice(null)}
 						/>
 					</div>,
-					noticePortalContainer,
+					document.body,
 				)}
 		</>
 	)

--- a/webview-ui/src/components/settings/__tests__/ModelPicker.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ModelPicker.spec.tsx
@@ -251,4 +251,45 @@ describe("ModelPicker", () => {
 			expect(screen.queryByText(errorMessage)).not.toBeInTheDocument()
 		})
 	})
+
+	it("renders a refresh button in the dropdown when onRefreshModels is provided and calls it on click", async () => {
+		const onRefreshModels = vi.fn()
+
+		await act(async () =>
+			render(
+				<QueryClientProvider client={queryClient}>
+					<ModelPicker {...defaultProps} onRefreshModels={onRefreshModels} />
+				</QueryClientProvider>,
+			),
+		)
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("combobox"))
+		})
+
+		const refreshButton = screen.getByTestId("model-picker-refresh")
+		expect(refreshButton).toBeInTheDocument()
+
+		await act(async () => {
+			fireEvent.click(refreshButton)
+		})
+
+		expect(onRefreshModels).toHaveBeenCalledTimes(1)
+	})
+
+	it("does not render the refresh button when onRefreshModels is not provided", async () => {
+		await act(async () =>
+			render(
+				<QueryClientProvider client={queryClient}>
+					<ModelPicker {...defaultProps} />
+				</QueryClientProvider>,
+			),
+		)
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("combobox"))
+		})
+
+		expect(screen.queryByTestId("model-picker-refresh")).not.toBeInTheDocument()
+	})
 })

--- a/webview-ui/src/components/settings/__tests__/ModelPicker.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ModelPicker.spec.tsx
@@ -292,4 +292,22 @@ describe("ModelPicker", () => {
 
 		expect(screen.queryByTestId("model-picker-refresh")).not.toBeInTheDocument()
 	})
+
+	it("disables the refresh button and spins the icon when isRefreshingModels is true", async () => {
+		await act(async () =>
+			render(
+				<QueryClientProvider client={queryClient}>
+					<ModelPicker {...defaultProps} onRefreshModels={vi.fn()} isRefreshingModels={true} />
+				</QueryClientProvider>,
+			),
+		)
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("combobox"))
+		})
+
+		const button = screen.getByTestId("model-picker-refresh")
+		expect(button).toBeDisabled()
+		expect(button.querySelector("svg")?.classList.contains("animate-spin")).toBe(true)
+	})
 })

--- a/webview-ui/src/components/settings/utils/correctModelSelection.spec.ts
+++ b/webview-ui/src/components/settings/utils/correctModelSelection.spec.ts
@@ -1,0 +1,37 @@
+// npx vitest run src/components/settings/utils/correctModelSelection.spec.ts
+
+import { describe, it, expect } from "vitest"
+
+import { getCorrectedCostrictModelId } from "./correctModelSelection"
+
+describe("getCorrectedCostrictModelId", () => {
+	it("returns null when no model is selected", () => {
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], undefined)).toBeNull()
+	})
+
+	it("returns null when the old list is empty (we don't know the server set yet)", () => {
+		expect(getCorrectedCostrictModelId([], ["Auto"], "qwen-max")).toBeNull()
+	})
+
+	it("returns null for a custom model that was never in the old list", () => {
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], "my-private-model")).toBeNull()
+	})
+
+	it("returns null when the selected model is still in the new list", () => {
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto", "qwen-max"], "qwen-max")).toBeNull()
+	})
+
+	it("returns Auto when a previously-listed server model was removed and Auto is available", () => {
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto", "qwen-plus"], "qwen-max")).toBe("Auto")
+	})
+
+	it("returns the first new model when Auto is absent from the new list", () => {
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["qwen-plus", "qwen-turbo"], "qwen-max")).toBe(
+			"qwen-plus",
+		)
+	})
+
+	it("returns null when the new list is empty (nothing to fall back to)", () => {
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], [], "qwen-max")).toBeNull()
+	})
+})

--- a/webview-ui/src/components/settings/utils/correctModelSelection.spec.ts
+++ b/webview-ui/src/components/settings/utils/correctModelSelection.spec.ts
@@ -34,4 +34,16 @@ describe("getCorrectedCostrictModelId", () => {
 	it("returns null when the new list is empty (nothing to fall back to)", () => {
 		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], [], "qwen-max")).toBeNull()
 	})
+
+	it("returns null when the selected model is an empty string", () => {
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], "")).toBeNull()
+	})
+
+	it("returns the sole model when the new list has exactly one element and Auto is absent", () => {
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["qwen-plus"], "qwen-max")).toBe("qwen-plus")
+	})
+
+	it("returns null for a custom model even when the new list is empty (guard order)", () => {
+		expect(getCorrectedCostrictModelId(["Auto"], [], "my-custom")).toBeNull()
+	})
 })

--- a/webview-ui/src/components/settings/utils/correctModelSelection.ts
+++ b/webview-ui/src/components/settings/utils/correctModelSelection.ts
@@ -1,0 +1,38 @@
+import { costrictDefaultModelId } from "@roo-code/types"
+
+/**
+ * Decide whether a stale costrict model selection must be corrected after the model
+ * list was refreshed, and if so, which model id to switch to.
+ *
+ * Rule (see docs/adr/0001-model-selection-correction.md):
+ * - Skip when the old list is empty — we don't yet know the legitimate server set.
+ * - Only correct a "server model": one that WAS in the old list. This protects a
+ *   user-typed "custom model" whose id is intentionally absent from the server list.
+ * - Only correct when that server model has disappeared from the new list.
+ * - Fall back to "Auto" (costrictDefaultModelId) when present in the new list,
+ *   otherwise the first model in the new list (guarantees an in-list, valid selection).
+ *
+ * @returns the model id to switch to, or null when no correction should happen.
+ */
+export function getCorrectedCostrictModelId(
+	oldModelIds: string[],
+	newModelIds: string[],
+	selectedModelId: string | undefined,
+): string | null {
+	if (!selectedModelId) {
+		return null
+	}
+	if (oldModelIds.length === 0) {
+		return null
+	}
+	if (!oldModelIds.includes(selectedModelId)) {
+		return null
+	}
+	if (newModelIds.includes(selectedModelId)) {
+		return null
+	}
+	if (newModelIds.length === 0) {
+		return null
+	}
+	return newModelIds.includes(costrictDefaultModelId) ? costrictDefaultModelId : newModelIds[0]
+}

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -151,6 +151,7 @@
 	},
 	"selectMode": "Select mode for interaction",
 	"selectModel": "Select model for interaction",
+	"modelAutoSwitched": "Model {{from}} is no longer available; switched to {{to}}.",
 	"selectApiConfig": "Select API configuration",
 	"lockApiConfigAcrossModes": "Lock API configuration across all modes in this workspace",
 	"unlockApiConfigAcrossModes": "API configuration is locked across all modes in this workspace (click to unlock)",

--- a/webview-ui/src/i18n/locales/zh-CN/chat.json
+++ b/webview-ui/src/i18n/locales/zh-CN/chat.json
@@ -124,6 +124,7 @@
 	},
 	"selectMode": "选择交互模式",
 	"selectModel": "选择模型",
+	"modelAutoSwitched": "原模型 {{from}} 已下线，已自动切换为 {{to}}。",
 	"selectApiConfig": "选择 API 配置",
 	"lockApiConfigAcrossModes": "锁定此工作区所有模式的 API 配置",
 	"unlockApiConfigAcrossModes": "此工作区所有模式的 API 配置已锁定（点击解锁）",

--- a/webview-ui/src/i18n/locales/zh-TW/chat.json
+++ b/webview-ui/src/i18n/locales/zh-TW/chat.json
@@ -151,6 +151,7 @@
 	},
 	"selectMode": "選擇互動模式",
 	"selectModel": "選擇模型",
+	"modelAutoSwitched": "原模型 {{from}} 已下線，已自動切換為 {{to}}。",
 	"selectApiConfig": "選取 API 設定",
 	"lockApiConfigAcrossModes": "鎖定此工作區所有模式的 API 設定",
 	"unlockApiConfigAcrossModes": "此工作區所有模式的 API 設定已鎖定（點擊解鎖）",


### PR DESCRIPTION
主要修改点：
  1. 登录即刷新:登录/重新登录时,自动拉取最新模型列表(不用再等 5 分钟缓存)。
  2. 下拉里加刷新按钮:对话框模型下拉的搜索框右侧新增刷新按钮(转圈反馈),随手点一下即可拿到最新列表。原设置页按钮保留。
  3. 失效模型自动纠偏:刷新后若发现你之前选中的"服务端模型"已下线,自动切换到 Auto(没有则切首个可用),避免拿失效模型发请求导致失败。手输的自定义模型不受影响、不会被覆盖。
  4. 纠偏提示:自动切换时,在模型选择器上方弹出一条轻量提示("原模型 X 已下线,已自动切换为 Auto"),约 6 秒消失,可手动关闭。

下面是计划：
# Costrict Model List Refresh Implementation Plan


**Goal:** Keep the costrict model list fresh (refresh it on login and via a discoverable button in the chat dialog) and auto-correct a stale model selection without clobbering user-typed custom models.

**Architecture:** Entirely webview-side, no extension-host changes. (1) `ModelPicker` gains an optional refresh icon button in its dropdown search row; `ProviderRenderer` wires it (costrict only) to the existing `flushRouterModels` round-trip, which the extension host already handles by flushing the cache and pushing a `costrictModels` message back. (2) On login, the extension host already posts `costrictLogined`; `ProviderRenderer` (always mounted inside `ChatView`) listens for it and reuses the very same refresh path — so login-refresh and button-refresh share one code path and the extension host is untouched. (3) Whenever a fresh `costrictModels` list arrives, a pure helper decides whether the selected model was a removed *server* model and, if so, switches it to `Auto` (or the first available model) and shows a lightweight inline notice. Custom models are never touched.

**Tech Stack:** TypeScript, React (webview-ui), vitest, i18next, Tailwind/vscrui, lucide-react icons, Radix Popover.

**Reference docs (read before starting):**
- `CONTEXT.md` — glossary: **Server model** vs **Custom model**, **Auto**, **Selection correction**.
- `docs/adr/0001-model-selection-correction.md` — why correction only applies to previously-seen server models.

**Design decisions baked in (do not "simplify" these away):**
- **No extension-host changes.** Login-refresh is triggered in the webview by listening for the existing `costrictLogined` message — NOT by importing `modelCache` into `authService`. That import would create runtime-fragile cycles (`authService → modelCache → core/costrict/auth (barrel) → authService`, and a second via `ClineProvider`). Avoid it entirely.
- **Login refresh fires unconditionally** (not gated on the current chat provider), so "log in → costrict list refreshes" always holds. This is only safe because of the next point.
- **Costrict and openai local model state are SEPARATE.** `ProviderRenderer` today reuses one `openAiModels` state for both providers, so a costrict refresh would overwrite the openai dropdown. Split them: a dedicated `costrictModelList` state feeds the costrict dropdown, `openAiModels` feeds the openai dropdown. A `costrictModels` push only ever touches `costrictModelList`.
- **The "old list" for correction is a dedicated costrict-only ref** (`previousCostrictModelsRef`), written only in the `costrictModels` branch and only when non-empty — so it always represents "the last non-empty costrict server list".
- **The inline notice is rendered through a Radix Popover, portaled into `#costrict-portal`** (not `document.body`). The toolbar chip is wrapped by an ancestor `overflow-clip` (ChatTextArea) and ProviderRenderer's own `overflow-hidden`, so an in-flow/absolute notice would be clipped. `#costrict-portal` lives inside ChatView's `isHidden ? "hidden"` wrapper: portaling there escapes the clip AND keeps the notice hidden when the chat tab isn't active (a plain `document.body` portal would wrongly show it over the Settings/Account tab).
- **Refresh goes through `flushRouterModels` (text `"costrict"`),** because that message is answered with a `costrictModels` push — exactly what the dropdown and the correction logic consume. Caveat (existing host behavior, `webviewMessageHandler.ts:1180`): the host only pushes `costrictModels` back when `apiConfiguration.apiProvider === "costrict"`. When the user is on another provider, the login refresh still flushes/refreshes the costrict **cache**, but the webview list/correction update lazily when they switch back to costrict (the picker then re-requests and reads the fresh cache). This is acceptable.

---

## File Structure

| File | Responsibility | Action |
|---|---|---|
| `webview-ui/src/components/settings/utils/correctModelSelection.ts` | Pure decision: does the stale selection need correcting, and to what id? | Create |
| `webview-ui/src/components/settings/utils/correctModelSelection.spec.ts` | Unit tests for the pure helper | Create |
| `webview-ui/src/components/settings/ModelPicker.tsx` | Add optional refresh button to the dropdown search row | Modify |
| `webview-ui/src/components/settings/__tests__/ModelPicker.spec.tsx` | Tests for the refresh button | Modify |
| `webview-ui/src/i18n/locales/{en,zh-CN,zh-TW}/chat.json` | `modelAutoSwitched` inline-notice string | Modify |
| `webview-ui/src/components/settings/ProviderRenderer.tsx` | Split state, refresh handler, login-trigger, correction, portaled notice | Modify |

---

## Task 1: Pure model-selection-correction helper

**Files:**
- Create: `webview-ui/src/components/settings/utils/correctModelSelection.ts`
- Test: `webview-ui/src/components/settings/utils/correctModelSelection.spec.ts`

- [ ] **Step 1: Write the failing test**

Create `webview-ui/src/components/settings/utils/correctModelSelection.spec.ts`:

```ts
// npx vitest run src/components/settings/utils/correctModelSelection.spec.ts

import { describe, it, expect } from "vitest"

import { getCorrectedCostrictModelId } from "./correctModelSelection"

describe("getCorrectedCostrictModelId", () => {
	it("returns null when no model is selected", () => {
		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], undefined)).toBeNull()
	})

	it("returns null when the old list is empty (we don't know the server set yet)", () => {
		expect(getCorrectedCostrictModelId([], ["Auto"], "qwen-max")).toBeNull()
	})

	it("returns null for a custom model that was never in the old list", () => {
		// User typed "my-private-model"; it was never a server model, so leave it alone.
		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], "my-private-model")).toBeNull()
	})

	it("returns null when the selected model is still in the new list", () => {
		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto", "qwen-max"], "qwen-max")).toBeNull()
	})

	it("returns Auto when a previously-listed server model was removed and Auto is available", () => {
		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto", "qwen-plus"], "qwen-max")).toBe("Auto")
	})

	it("returns the first new model when Auto is absent from the new list", () => {
		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["qwen-plus", "qwen-turbo"], "qwen-max")).toBe(
			"qwen-plus",
		)
	})

	it("returns null when the new list is empty (nothing to fall back to)", () => {
		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], [], "qwen-max")).toBeNull()
	})
})
```

- [ ] **Step 2: Run test to verify it fails**

Run: `cd webview-ui && npx vitest run src/components/settings/utils/correctModelSelection.spec.ts`
Expected: FAIL — cannot find module `./correctModelSelection`.

- [ ] **Step 3: Write minimal implementation**

Create `webview-ui/src/components/settings/utils/correctModelSelection.ts`:

```ts
import { costrictDefaultModelId } from "@roo-code/types"

/**
 * Decide whether a stale costrict model selection must be corrected after the model
 * list was refreshed, and if so, which model id to switch to.
 *
 * Rule (see docs/adr/0001-model-selection-correction.md):
 * - Skip when the old list is empty — we don't yet know the legitimate server set.
 * - Only correct a "server model": one that WAS in the old list. This protects a
 *   user-typed "custom model" whose id is intentionally absent from the server list.
 * - Only correct when that server model has disappeared from the new list.
 * - Fall back to "Auto" (costrictDefaultModelId) when present in the new list,
 *   otherwise the first model in the new list (guarantees an in-list, valid selection).
 *
 * @returns the model id to switch to, or null when no correction should happen.
 */
export function getCorrectedCostrictModelId(
	oldModelIds: string[],
	newModelIds: string[],
	selectedModelId: string | undefined,
): string | null {
	if (!selectedModelId) {
		return null
	}
	if (oldModelIds.length === 0) {
		return null
	}
	if (!oldModelIds.includes(selectedModelId)) {
		return null
	}
	if (newModelIds.includes(selectedModelId)) {
		return null
	}
	if (newModelIds.length === 0) {
		return null
	}
	return newModelIds.includes(costrictDefaultModelId) ? costrictDefaultModelId : newModelIds[0]
}
```

- [ ] **Step 4: Run test to verify it passes**

Run: `cd webview-ui && npx vitest run src/components/settings/utils/correctModelSelection.spec.ts`
Expected: PASS — 7 passing.

- [ ] **Step 5: Commit**

```bash
git add webview-ui/src/components/settings/utils/correctModelSelection.ts webview-ui/src/components/settings/utils/correctModelSelection.spec.ts
git commit -m "feat(models): add pure costrict model-selection-correction helper"
```

---

## Task 2: Refresh button in the ModelPicker dropdown

**Files:**
- Modify: `webview-ui/src/components/settings/ModelPicker.tsx`
- Test: `webview-ui/src/components/settings/__tests__/ModelPicker.spec.tsx`

- [ ] **Step 1: Write the failing test**

Append these two tests inside the top-level `describe("ModelPicker", () => { ... })` block in `webview-ui/src/components/settings/__tests__/ModelPicker.spec.tsx` (place them after the existing `it(...)` blocks, before the closing `})` of the describe):

```ts
	it("renders a refresh button in the dropdown when onRefreshModels is provided and calls it on click", async () => {
		const onRefreshModels = vi.fn()

		await act(async () =>
			render(
				<QueryClientProvider client={queryClient}>
					<ModelPicker {...defaultProps} onRefreshModels={onRefreshModels} />
				</QueryClientProvider>,
			),
		)

		await act(async () => {
			fireEvent.click(screen.getByRole("combobox"))
		})

		const refreshButton = screen.getByTestId("model-picker-refresh")
		expect(refreshButton).toBeInTheDocument()

		await act(async () => {
			fireEvent.click(refreshButton)
		})

		expect(onRefreshModels).toHaveBeenCalledTimes(1)
	})

	it("does not render the refresh button when onRefreshModels is not provided", async () => {
		await act(async () =>
			render(
				<QueryClientProvider client={queryClient}>
					<ModelPicker {...defaultProps} />
				</QueryClientProvider>,
			),
		)

		await act(async () => {
			fireEvent.click(screen.getByRole("combobox"))
		})

		expect(screen.queryByTestId("model-picker-refresh")).not.toBeInTheDocument()
	})
```

- [ ] **Step 2: Run test to verify it fails**

Run: `cd webview-ui && npx vitest run src/components/settings/__tests__/ModelPicker.spec.tsx -t "refresh button"`
Expected: FAIL — `model-picker-refresh` test id not found.

- [ ] **Step 3a: Add the RefreshCw icon import**

In `webview-ui/src/components/settings/ModelPicker.tsx`, change the lucide-react import (line 4):

```ts
import { ChevronsUpDown, Check, X, Brain, Info, RefreshCw } from "lucide-react"
```

- [ ] **Step 3b: Add the two new props to the interface**

In `interface ModelPickerProps` (around line 46-79), add after the `isStreaming?: boolean` line:

```ts
	isStreaming?: boolean
	/** When provided, renders a refresh button in the dropdown search row that calls this on click. */
	onRefreshModels?: () => void
	/** Spins the refresh icon and disables the button while a refresh is in flight. */
	isRefreshingModels?: boolean
```

- [ ] **Step 3c: Destructure the new props**

In the component parameter destructuring (around line 81-105), add after the `isStreaming = false,` line:

```ts
	isStreaming = false,
	onRefreshModels,
	isRefreshingModels = false,
```

- [ ] **Step 3d: Render the refresh button in the search row**

Replace the search-input block (currently lines 302-319):

```tsx
							<div className="relative">
								<CommandInput
									ref={searchInputRef}
									value={searchValue}
									onValueChange={setSearchValue}
									placeholder={t("settings:modelPicker.searchPlaceholder")}
									className="h-9 mr-4"
									data-testid="model-input"
								/>
								{searchValue.length > 0 && (
									<div className="absolute right-2 top-0 bottom-0 flex items-center justify-center">
										<X
											className="text-vscode-input-foreground opacity-50 hover:opacity-100 size-4 p-0.5 cursor-pointer"
											onClick={onClearSearch}
										/>
									</div>
								)}
							</div>
```

with:

```tsx
							<div className="flex items-stretch">
								<div className="relative flex-1">
									<CommandInput
										ref={searchInputRef}
										value={searchValue}
										onValueChange={setSearchValue}
										placeholder={t("settings:modelPicker.searchPlaceholder")}
										className="h-9 mr-4"
										data-testid="model-input"
									/>
									{searchValue.length > 0 && (
										<div className="absolute right-2 top-0 bottom-0 flex items-center justify-center">
											<X
												className="text-vscode-input-foreground opacity-50 hover:opacity-100 size-4 p-0.5 cursor-pointer"
												onClick={onClearSearch}
											/>
										</div>
									)}
								</div>
								{onRefreshModels && (
									<StandardTooltip content={t("settings:providers.refreshModels.label")}>
										<button
											type="button"
											aria-label={t("settings:providers.refreshModels.label")}
											data-testid="model-picker-refresh"
											disabled={isRefreshingModels}
											onClick={(e) => {
												e.stopPropagation()
												onRefreshModels()
											}}
											className="flex shrink-0 items-center justify-center self-stretch border-b border-vscode-dropdown-border px-2.5 text-vscode-input-foreground opacity-60 hover:opacity-100 disabled:cursor-default disabled:opacity-40 cursor-pointer">
											<RefreshCw className={cn("size-4", isRefreshingModels && "animate-spin")} />
										</button>
									</StandardTooltip>
								)}
							</div>
```

Note: `StandardTooltip` and `cn` are already imported in this file (lines 25 and 11).

- [ ] **Step 4: Run test to verify it passes**

Run: `cd webview-ui && npx vitest run src/components/settings/__tests__/ModelPicker.spec.tsx`
Expected: PASS — including the two new tests, and all existing ModelPicker tests still green.

- [ ] **Step 5: Commit**

```bash
git add webview-ui/src/components/settings/ModelPicker.tsx webview-ui/src/components/settings/__tests__/ModelPicker.spec.tsx
git commit -m "feat(models): add optional refresh button to ModelPicker dropdown"
```

---

## Task 3: Add the inline-notice i18n string

**Files:**
- Modify: `webview-ui/src/i18n/locales/en/chat.json`
- Modify: `webview-ui/src/i18n/locales/zh-CN/chat.json`
- Modify: `webview-ui/src/i18n/locales/zh-TW/chat.json`

- [ ] **Step 1: Add the English string**

In `webview-ui/src/i18n/locales/en/chat.json`, find the line `"selectModel": "Select model for interaction",` and add immediately after it:

```json
	"modelAutoSwitched": "Model {{from}} is no longer available; switched to {{to}}.",
```

- [ ] **Step 2: Add the Simplified Chinese string**

In `webview-ui/src/i18n/locales/zh-CN/chat.json`, find the line `"selectModel": "选择模型",` and add immediately after it:

```json
	"modelAutoSwitched": "原模型 {{from}} 已下线，已自动切换为 {{to}}。",
```

- [ ] **Step 3: Add the Traditional Chinese string**

In `webview-ui/src/i18n/locales/zh-TW/chat.json`, find the `"selectModel"` line and add immediately after it:

```json
	"modelAutoSwitched": "原模型 {{from}} 已下線，已自動切換為 {{to}}。",
```

- [ ] **Step 4: Verify JSON is valid**

Run: `cd webview-ui && node -e "['en','zh-CN','zh-TW'].forEach(l=>{require('./src/i18n/locales/'+l+'/chat.json');console.log(l,'ok')})"`
Expected: `en ok` / `zh-CN ok` / `zh-TW ok` (no JSON parse error).

- [ ] **Step 5: Commit**

```bash
git add webview-ui/src/i18n/locales/en/chat.json webview-ui/src/i18n/locales/zh-CN/chat.json webview-ui/src/i18n/locales/zh-TW/chat.json
git commit -m "feat(i18n): add modelAutoSwitched inline-notice string"
```

---

## Task 4: ProviderRenderer — split state, refresh, login-trigger, correction, portaled notice

**Files:**
- Modify: `webview-ui/src/components/settings/ProviderRenderer.tsx`

This task has no automated test (ProviderRenderer has no existing test harness and depends on heavy webview context). Its core decision logic is unit-tested in Task 1; the wiring is verified by `pnpm check-types` and the manual steps at the end.

**Wiring contract (read first):**
- `costrictModelList` (new state) feeds the costrict dropdown; `openAiModels` (existing state) feeds only the openai dropdown. A `costrictModels` message updates `costrictModelList` only — never `openAiModels`. This is what makes the unconditional login refresh safe.
- `previousCostrictModelsRef` holds the last non-empty costrict server list (written only in the `costrictModels` branch). It is the "old list" for correction.
- `selectedModelIdRef` mirrors `apiConfiguration.costrictModelId`, updated by an effect (external changes) AND synchronously by the wrapped setter (closes the just-typed-custom-model race).
- The inline notice renders in a controlled Radix `Popover` (`PopoverContent` portals out, escaping the `overflow-clip` ancestor).

- [ ] **Step 1: Update the React import to include `useRef`**

Change line 1 of `webview-ui/src/components/settings/ProviderRenderer.tsx`:

```ts
import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
```

- [ ] **Step 2: Add Popover primitives to the ui import**

Change the `@src/components/ui` import (line 21) from:

```ts
import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, StandardTooltip } from "@src/components/ui"
```

to:

```ts
import {
	Select,
	SelectTrigger,
	SelectValue,
	SelectContent,
	SelectItem,
	StandardTooltip,
	Popover,
	PopoverAnchor,
	PopoverContent,
} from "@src/components/ui"
```

- [ ] **Step 3: Add lucide icons + the correction helper import**

Change the lucide-react import (line 24) from `import { Brain } from "lucide-react"` to:

```ts
import { Brain, Info, X } from "lucide-react"
```

Add these imports after the existing `import { cn } from "@/lib/utils"` line (line 25):

```ts
import { getCorrectedCostrictModelId } from "./utils/correctModelSelection"
import { useRooPortal } from "@/components/ui/hooks/useRooPortal"
```

(`vscode` is already imported on line 19.)

`useRooPortal("costrict-portal")` returns the `#costrict-portal` element that lives inside ChatView's `isHidden ? "hidden" : ...` wrapper (ChatView.tsx:2191). Portaling the notice there means it (a) escapes the toolbar's `overflow-clip`, AND (b) is hidden together with the chat tab — so a login/correction while on the Settings or Account tab will NOT render the notice over the wrong page.

- [ ] **Step 4: Add the dedicated costrict state, refs, wrapped setter, handlers, and login listener**

Immediately after the existing `const [openAiModels, setOpenAiModels] = useState<Record<string, ModelInfo> | null>(null)` line (line 49), add:

```ts
	// Dedicated costrict model list — separate from openAiModels so a costrict refresh
	// (incl. the unconditional login refresh) never overwrites the openai dropdown.
	const [costrictModelList, setCostrictModelList] = useState<Record<string, ModelInfo> | null>(null)
	const [isRefreshing, setIsRefreshing] = useState(false)
	const [autoSwitchNotice, setAutoSwitchNotice] = useState<{ from: string; to: string } | null>(null)

	// Container for the inline notice. Lives inside ChatView's hidden wrapper, so the notice
	// escapes the toolbar's overflow-clip yet stays hidden when the chat tab is not active.
	const noticePortalContainer = useRooPortal("costrict-portal")

	// Last NON-EMPTY costrict server list; the "old list" baseline for correction.
	const previousCostrictModelsRef = useRef<Record<string, ModelInfo> | null>(null)
	// Mirrors apiConfiguration.costrictModelId; kept fresh by the effect below AND synchronously
	// by the wrapped setter, so a just-typed custom model can't be mis-corrected by a racing refresh.
	const selectedModelIdRef = useRef<string | undefined>(apiConfiguration.costrictModelId)
	const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)

	useEffect(() => {
		selectedModelIdRef.current = apiConfiguration.costrictModelId
	}, [apiConfiguration.costrictModelId])

	// Wrapped setter: synchronously syncs the ref for costrictModelId before delegating.
	const setApiConfigurationFieldWithRef = useCallback(
		<K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => {
			if (field === "costrictModelId") {
				selectedModelIdRef.current = value as ProviderSettings["costrictModelId"]
			}
			setApiConfigurationField(field, value)
		},
		[setApiConfigurationField],
	)
	const setFieldRef = useRef(setApiConfigurationFieldWithRef)
	useEffect(() => {
		setFieldRef.current = setApiConfigurationFieldWithRef
	}, [setApiConfigurationFieldWithRef])

	// Auto-dismiss the inline notice after a few seconds.
	useEffect(() => {
		if (!autoSwitchNotice) {
			return
		}
		const timer = setTimeout(() => setAutoSwitchNotice(null), 6000)
		return () => clearTimeout(timer)
	}, [autoSwitchNotice])

	// Dismiss the notice once the user picks a different model than the one we corrected to.
	useEffect(() => {
		if (autoSwitchNotice && apiConfiguration.costrictModelId !== autoSwitchNotice.to) {
			setAutoSwitchNotice(null)
		}
	}, [apiConfiguration.costrictModelId, autoSwitchNotice])

	useEffect(() => {
		return () => {
			if (refreshTimeoutRef.current) {
				clearTimeout(refreshTimeoutRef.current)
			}
		}
	}, [])

	const handleRefreshModels = useCallback(() => {
		// Costrict round-trip: host flushes the cache, refetches, and pushes `costrictModels` back.
		vscode.postMessage({ type: "flushRouterModels", text: "costrict" })
		setIsRefreshing(true)
		if (refreshTimeoutRef.current) {
			clearTimeout(refreshTimeoutRef.current)
		}
		// Safety fallback: stop spinning even if no response arrives.
		refreshTimeoutRef.current = setTimeout(() => setIsRefreshing(false), 10000)
	}, [])

	// Login refresh: ProviderRenderer is always mounted (ChatView is never unmounted), so it
	// reliably catches the host's post-login `costrictLogined`. Fire unconditionally — refreshing
	// the costrict list only touches `costrictModelList`, never the openai dropdown.
	useEffect(() => {
		const onLogined = (event: MessageEvent) => {
			if (event.data?.type === "costrictLogined") {
				handleRefreshModels()
			}
		}
		window.addEventListener("message", onLogined)
		return () => window.removeEventListener("message", onLogined)
	}, [handleRefreshModels])
```

- [ ] **Step 5: Replace the `costrictModels` branch of `onMessage`**

Replace the existing `onMessage` callback (lines 51-70) with:

```ts
	const onMessage = useCallback((event: MessageEvent) => {
		const message: ExtensionMessage = event.data

		switch (message.type) {
			case "costrictModels": {
				const { fullResponseData = [] } = message
				const newModels = Object.fromEntries(
					fullResponseData.map((item) => [item.id, { ...(item ?? costrictModels.default) }]),
				) as Record<string, ModelInfo>
				const newModelIds = Object.keys(newModels)

				// Selection correction: compare against the dedicated costrict baseline.
				// The pure rule (and its rationale) lives in ./utils/correctModelSelection.
				const oldModelIds = Object.keys(previousCostrictModelsRef.current ?? {})
				const selectedModelId = selectedModelIdRef.current
				const corrected = getCorrectedCostrictModelId(oldModelIds, newModelIds, selectedModelId)
				if (corrected && selectedModelId) {
					setFieldRef.current("costrictModelId", corrected)
					setAutoSwitchNotice({ from: selectedModelId, to: corrected })
				}

				// Preserve the last NON-EMPTY costrict list as the baseline for the next refresh.
				if (newModelIds.length > 0) {
					previousCostrictModelsRef.current = newModels
				}

				setCostrictModelList(newModels)
				setIsRefreshing(false)
				break
			}
			case "openAiModels": {
				const updatedModels = message.openAiModels ?? []
				setOpenAiModels(Object.fromEntries(updatedModels.map((item) => [item, openAiModelInfoSaneDefaults])))
				break
			}
		}
	}, [])
```

- [ ] **Step 6: Point the costrict provider config at the new state**

In the `providerConfig` `useMemo` (lines 156-202), change the costrict entry's `models` (line 163) from:

```ts
				models: openAiModels ?? {},
```

to:

```ts
				models: costrictModelList ?? {},
```

Leave the `openai` entry's `models: openAiModels ?? {}` (line 191) unchanged. Then update the `useMemo` dependency array (line 201) from:

```ts
		[apiConfiguration.costrictModelId, apiConfiguration.costrictBaseUrl, openAiModels, routerModels],
```

to:

```ts
		[apiConfiguration.costrictModelId, apiConfiguration.costrictBaseUrl, costrictModelList, openAiModels, routerModels],
```

- [ ] **Step 7: Wrap the return in a Popover (portaled notice) and pass the new props**

The current `return` (lines 218-287) is structured as:

```tsx
	return (
		<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
			{config?.modelIdKey ? (
				<ModelPicker ... />
			) : (
				selectedProviderModels.length > 0 && ( ...Select... )
			)}
		</div>
	)
```

Change it to wrap the existing root `<div>` in a controlled `Popover` + `PopoverAnchor`, and add the `PopoverContent` notice as a sibling that portals out:

```tsx
	return (
		<Popover open={!!autoSwitchNotice} onOpenChange={(o) => !o && setAutoSwitchNotice(null)}>
			<PopoverAnchor asChild>
				<div className={cn(className, config?.modelIdKey || selectedProviderModels.length > 0 ? "" : "hidden")}>
					{/* ...the existing ModelPicker / Select block stays here, UNCHANGED except the two prop edits below... */}
				</div>
			</PopoverAnchor>
			{autoSwitchNotice && noticePortalContainer && (
				<PopoverContent
					container={noticePortalContainer}
					side="top"
					align="start"
					onOpenAutoFocus={(e) => e.preventDefault()}
					className="z-50 flex w-auto max-w-80 items-center gap-1 whitespace-normal rounded-md border border-vscode-dropdown-border bg-vscode-input-background px-2 py-1 text-xs text-vscode-descriptionForeground shadow">
					<Info className="size-3 shrink-0" />
					<span className="flex-1">
						{t("chat:modelAutoSwitched", { from: autoSwitchNotice.from, to: autoSwitchNotice.to })}
					</span>
					<X
						className="size-3 shrink-0 cursor-pointer opacity-70 hover:opacity-100"
						onClick={() => setAutoSwitchNotice(null)}
					/>
				</PopoverContent>
			)}
		</Popover>
	)
```

Inside the preserved `<ModelPicker ... />` element (lines 221-238), make two prop edits:

(a) Change the `setApiConfigurationField` prop to pass the wrapped setter:

```tsx
						setApiConfigurationField={setApiConfigurationFieldWithRef}
```

(b) Add these two props after `isStreaming={isStreaming}` (line 234):

```tsx
						isStreaming={isStreaming}
						onRefreshModels={selectedProvider === "costrict" ? handleRefreshModels : undefined}
						isRefreshingModels={isRefreshing}
```

(The `Select` branch for non-costrict providers stays exactly as-is.)

- [ ] **Step 8: Type-check**

Run: `pnpm check-types`
Expected: PASS — no type errors. (Confirms the split state, props, wrapped-setter generic, Popover usage, and the `t("chat:modelAutoSwitched", ...)` call.)

- [ ] **Step 9: Manual verification**

Build/run the extension (or use an existing dev host) and verify:
1. Open the chat dialog with costrict selected → open the model dropdown → a refresh icon sits at the right of the search row; clicking it spins the icon and the list updates.
2. With `costrictModelId` set to an existing model, simulate its removal and click refresh → selection flips to `Auto`, and the inline notice appears above the model selector (NOT clipped), auto-dismissing after ~6s and closeable via ×.
3. Type a custom model id not in the list, then refresh → the custom id is **preserved** (no correction, no notice).
4. Log out, then log in via OAuth while the chat provider is **openai** → the openai dropdown is NOT replaced by costrict models; switching to costrict shows the freshly-refreshed costrict list.
5. Log in while the chat provider is **costrict** → the costrict list refreshes automatically (same path as the button).
6. Trigger a correction, then immediately switch to the **Settings** tab → the inline notice does NOT appear over the settings page (it lives in `#costrict-portal`, hidden with the chat tab).

- [ ] **Step 10: Commit**

```bash
git add webview-ui/src/components/settings/ProviderRenderer.tsx
git commit -m "feat(models): chat-dialog refresh button, login refresh, and stale-selection correction"
```

---

## Final verification

- [ ] **Run the touched webview tests**

Run: `cd webview-ui && npx vitest run src/components/settings/utils/correctModelSelection.spec.ts src/components/settings/__tests__/ModelPicker.spec.tsx`
Expected: PASS.

- [ ] **Run type checks across the monorepo**

Run: `pnpm check-types`
Expected: PASS.

- [ ] **Run lint**

Run: `pnpm lint`
Expected: PASS (or no new violations in the files touched by this plan).

---

## Self-Review Notes (coverage against the agreed spec)

- **Req 1 — refresh on login (login event, unconditional):** Task 4 Step 4 (`costrictLogined` listener reusing `handleRefreshModels`, fired regardless of current provider). No extension-host change → no import cycle.
- **Req 2 — discoverable refresh button, dropdown search row, costrict only:** Task 2 (button) + Task 4 Step 7 (costrict-only wiring via `flushRouterModels`). Settings-page button left untouched.
- **Selection correction (login + manual, guarded):** Task 1 (pure rule) + Task 4 Step 5 (invoked on every `costrictModels` arrival, using the dedicated `previousCostrictModelsRef` baseline).
- **Inline notice (dialog, portaled, auto-dismiss ~6s + manual close + clears on user re-pick, only when corrected):** Task 4 Steps 4 & 7 + Task 3 (string).
- **Codex review fixes folded in (round 1 + round 2):** (a) no `authService → modelCache` cycle (login handled in webview); (b) correction uses `previousCostrictModelsRef`, not the shared state; (c) wrapped setter syncs `selectedModelIdRef` (custom-model race); (d) Auto-absent fallback kept as first-available (confirmed); (e) **costrict/openai model state split** so login refresh can fire unconditionally without corrupting the openai dropdown; (f) **notice rendered via Radix Popover portaled into `#costrict-portal`** — escapes the `overflow-clip` ancestor AND stays hidden when the chat tab is inactive (round 3 fix).
- **Type consistency:** `getCorrectedCostrictModelId(oldModelIds, newModelIds, selectedModelId)` matches between Tasks 1 and 4; `onRefreshModels` / `isRefreshingModels` prop names match between Tasks 2 and 4; `costrictModels` message shape (`openAiModels` + `fullResponseData`) matches the existing `ExtensionMessage` type.
- **Known limitation:** login while parked on the Settings/Account tab still triggers the refresh (ChatView is always mounted) and applies correction, but the notice is hidden with the chat tab (it lives in `#costrict-portal`) and may auto-dismiss before the user returns — they see the corrected selection but might miss the one-time notice. Acceptable.
