### PR TITLE
feat(cs-cloud): split reconnect and server restart, rename ownership/source enums

### DIFF
--- a/src/__tests__/assistant-ui-cscloud-service.spec.ts
+++ b/src/__tests__/assistant-ui-cscloud-service.spec.ts
@@ -192,14 +192,67 @@ describe("CsCloudService (refactored)", () => {
 		expect(svc.state).toBe("error")
 	})
 
-	it("restart clears state and re-resolves", async () => {
+	it("reconnect clears state and re-resolves", async () => {
 		setServerUrlFile("http://127.0.0.1:59249")
 		mockHealthOk()
 		const svc = new CsCloudService(createOutputChannel() as never)
 		await svc.ensureStarted()
 		expect(svc.state).toBe("running")
 		setServerUrlFile("http://127.0.0.1:60000")
-		await expect(svc.restart()).resolves.toBe("http://127.0.0.1:60000/api/v1")
+		await expect(svc.reconnect()).resolves.toBe("http://127.0.0.1:60000/api/v1")
+		expect(mockCrossSpawn).not.toHaveBeenCalled()
+	})
+
+	it("restartServer uses bundled cs-cloud restart when bundled binary exists", async () => {
+		setServerUrlFile("http://127.0.0.1:59249")
+		mockHealthOk()
+
+		const svc = new CsCloudService(createOutputChannel() as never)
+		await expect(svc.restartServer()).resolves.toBe("http://127.0.0.1:59249/api/v1")
+
+		expect(mockCrossSpawn).toHaveBeenCalledWith(
+			"/home/testuser/.costrict/bin/cs-cloud",
+			["restart"],
+			expect.objectContaining({ env: expect.any(Object), stdio: "pipe" }),
+		)
+		expect(svc.processOwner).toBe("extension")
+		expect(svc.connectionSource).toBe("bundledBinary")
+	})
+
+	it("restartServer uses global csc cloud restart when bundled binary is missing", async () => {
+		mockFs.existsSync.mockImplementation((p: string) => p.toString().endsWith("server_url"))
+		mockFs.readFileSync.mockReturnValue("http://127.0.0.1:59249")
+		mockWhich.mockResolvedValue("/usr/local/bin/csc")
+		mockHealthOk()
+
+		const svc = new CsCloudService(createOutputChannel() as never)
+		await expect(svc.restartServer()).resolves.toBe("http://127.0.0.1:59249/api/v1")
+
+		expect(mockCrossSpawn).toHaveBeenCalledWith(
+			"/usr/local/bin/csc",
+			["cloud", "restart"],
+			expect.objectContaining({ env: expect.any(Object), stdio: "pipe" }),
+		)
+		expect(svc.processOwner).toBe("external")
+		expect(svc.connectionSource).toBe("cliRestart")
+	})
+
+	it("configured baseUrl reconnect keeps reconnect behavior", async () => {
+		setConfigValues({ baseUrl: "http://custom:8080/api/v1", port: 45489 })
+
+		const svc = new CsCloudService(createOutputChannel() as never)
+		await expect(svc.reconnect()).resolves.toBe("http://custom:8080/api/v1")
+
+		expect(mockCrossSpawn).not.toHaveBeenCalled()
+	})
+
+	it("configured baseUrl restartServer is rejected", async () => {
+		setConfigValues({ baseUrl: "http://custom:8080/api/v1", port: 45489 })
+
+		const svc = new CsCloudService(createOutputChannel() as never)
+		await expect(svc.restartServer()).rejects.toThrow("Cannot restart configured external cs-cloud baseUrl")
+
+		expect(mockCrossSpawn).not.toHaveBeenCalled()
 	})
 
 	it("deduplicates concurrent ensureStarted calls", async () => {
@@ -241,7 +294,7 @@ describe("CsCloudService (refactored)", () => {
 		const svc = new CsCloudService(createOutputChannel() as never)
 		await svc.ensureStarted()
 		expect(svc.state).toBe("running")
-		expect(svc.ownership).toBe("owned")
+		expect(svc.processOwner).toBe("extension")
 		expect(spawnExitRegistered).toBe(true)
 	})
 
@@ -252,7 +305,7 @@ describe("CsCloudService (refactored)", () => {
 		const svc = new CsCloudService(createOutputChannel() as never)
 		await svc.ensureStarted()
 		expect(svc.state).toBe("running")
-		expect(svc.ownership).toBe("unmanaged")
+		expect(svc.processOwner).toBe("external")
 
 		const crashedPromise = new Promise<string>((resolve) => {
 			svc.on("crashed", ({ reason }: { reason: string }) => resolve(reason))

--- a/src/__tests__/assistant-ui-panel.spec.ts
+++ b/src/__tests__/assistant-ui-panel.spec.ts
@@ -36,6 +36,7 @@ import {
 	addNonceToScriptTags,
 	injectIntoHead,
 	buildAssistantUIFrameUrl,
+	getAssistantUIIframeHtml,
 	getAssistantUIStaticHtml,
 	getAssistantUIStaticOutDir,
 	rewriteStaticAssetUrls,
@@ -230,10 +231,29 @@ describe("AssistantUIPanel", () => {
 
 			expect(html).toContain("http://127.0.0.1:45489")
 			expect(html).toContain(`href="vscode-resource:${outDir}/costrict/logo.png"`)
+			expect(html).toContain('e.data?.type === "restartCsCloudServer"')
+			expect(html).toContain('v.postMessage({ type: "restartCsCloudServer" })')
 			expect(html).not.toContain('href="/costrict/logo.png"')
 		} finally {
 			fs.rmSync(extensionRoot, { recursive: true, force: true })
 		}
+	})
+
+	it("forwards server restart messages between iframe and extension host", () => {
+		const webview = {
+			cspSource: "vscode-webview://test-csp-source",
+		}
+
+		const html = getAssistantUIIframeHtml(
+			webview as never,
+			{ extensionUri: { fsPath: "/tmp/test-extension" } } as never,
+			"http://127.0.0.1:45489/api/v1",
+			"http://127.0.0.1:3000",
+		)
+
+		expect(html).toContain('event.data?.type === "restartCsCloudServer"')
+		expect(html).toContain('vscodeApi.postMessage({ type: "restartCsCloudServer" })')
+		expect(html).toContain('event.data?.type === "restartCsCloudServerFailed"')
 	})
 
 	it("preserves Request method, headers, and body in the static Webview fetch proxy", () => {

--- a/src/core/cs-cloud/extension/csCloudService.ts
+++ b/src/core/cs-cloud/extension/csCloudService.ts
@@ -9,21 +9,36 @@ import crossSpawn from "cross-spawn"
 import * as vscode from "vscode"
 import { getAssistantUIConfig } from "./config"
 
-export type CsCloudOwnership = "owned" | "unmanaged"
-export type CsCloudSource = "spawned" | "detected" | "configuredBaseUrl"
+export type CsCloudServiceState = "idle" | "loading" | "running" | "error"
+export type CsCloudProcessOwner = "extension" | "external"
+export type CsCloudConnectionSource =
+	| "configuredBaseUrl"
+	| "serverUrlFile"
+	| "bundledBinary"
+	| "cliStatus"
+	| "cliRestart"
+
+type CsCloudConnectionRefreshOperation = {
+	logBranch: string
+	operationLabel: string
+	startMessage: string
+	successMessage: string
+	validate?: () => void
+	run: () => Promise<string>
+}
 
 /**
  * cs-cloud service manager.
  *
  * Discovery: configuredUrl → server_url file → bundled binary → CLI status → error
  * Crash detection: process exit, heartbeat (15s × 3), file watcher
- * Auto recovery: owned process retries 3x with exponential backoff
+ * Auto recovery: extension-owned process retries 3x with exponential backoff
  * Events: "crashed" { reason }, "urlChanged" { url }
  */
 export class CsCloudService extends EventEmitter implements vscode.Disposable {
-	state: "idle" | "loading" | "running" | "error" = "idle"
-	ownership: CsCloudOwnership = "owned"
-	source: CsCloudSource = "spawned"
+	state: CsCloudServiceState = "idle"
+	processOwner: CsCloudProcessOwner = "extension"
+	connectionSource: CsCloudConnectionSource = "bundledBinary"
 
 	lastCrashReason?: string
 	startupFailureReason?: string
@@ -35,11 +50,12 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 	private childProcess?: ReturnType<typeof crossSpawn>
 	private healthCheckTimer?: ReturnType<typeof setInterval>
 	private healthCheckFailures = 0
-	private autoRestartCount = 0
+	private autoReconnectCount = 0
 
 	private readonly HEALTH_CHECK_INTERVAL = 15_000
 	private readonly HEALTH_CHECK_FAILURE_THRESHOLD = 3
-	private readonly MAX_AUTO_RESTARTS = 3
+	private readonly MAX_AUTO_RECONNECTS = 3
+	private readonly RESTART_READY_TIMEOUT = 30_000
 
 	constructor(private readonly outputChannel: vscode.OutputChannel) {
 		super()
@@ -107,8 +123,8 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 		if (config.baseUrl.trim()) {
 			this.log(1, "configuredUrl", `Using configured baseUrl: "${config.baseUrl}"`)
 			this.baseUrl = trimTrailingSlash(config.baseUrl.trim())
-			this.ownership = "unmanaged"
-			this.source = "configuredBaseUrl"
+			this.processOwner = "external"
+			this.connectionSource = "configuredBaseUrl"
 			return this.baseUrl
 		}
 		this.log(1, "configuredUrl", "No baseUrl configured, skipping")
@@ -125,8 +141,8 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 
 			if (healthy) {
 				this.baseUrl = `${fileUrl}/api/v1`
-				this.ownership = "unmanaged"
-				this.source = "detected"
+				this.processOwner = "external"
+				this.connectionSource = "serverUrlFile"
 				this.log(2, "serverUrlFile", "✓ Health check passed, using this address")
 				return this.baseUrl
 			}
@@ -140,8 +156,8 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 		this.log(3, "bundledBin", `Checking binary: ${this.bundledBinPath} → ${hasBin ? "exists" : "not found"}`)
 
 		if (hasBin) {
-			this.ownership = "owned"
-			this.source = "spawned"
+			this.processOwner = "extension"
+			this.connectionSource = "bundledBinary"
 
 			this.log(3, "bundledBin", `spawn: ${this.bundledBinPath} cloud start --port ${config.port} --host 0.0.0.0`)
 			try {
@@ -179,8 +195,8 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 		const cliUrl = await this.detectViaCliStatus(cscCliPath)
 		if (cliUrl) {
 			this.baseUrl = cliUrl
-			this.ownership = "unmanaged"
-			this.source = "detected"
+			this.processOwner = "external"
+			this.connectionSource = "cliStatus"
 			this.log(4, "cliStatus", `✓ Detected running instance → ${cliUrl}`)
 			return cliUrl
 		}
@@ -191,12 +207,63 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 		throw new Error("Please run manually: csc cloud start\n Then restart the editor")
 	}
 
-	async restart(): Promise<string> {
+	async reconnect(): Promise<string> {
+		return this.runConnectionRefreshOperation({
+			logBranch: "reconnect",
+			operationLabel: "Reconnect",
+			startMessage: "Starting reconnect...",
+			successMessage: "Reconnect successful",
+			run: () => this.doEnsureStarted(),
+		})
+	}
+
+	async restartServer(): Promise<string> {
+		return this.runConnectionRefreshOperation({
+			logBranch: "restartServer",
+			operationLabel: "Server restart",
+			startMessage: "Starting server restart...",
+			successMessage: "Server restart successful",
+			validate: () => {
+				const config = getAssistantUIConfig()
+				if (config.baseUrl.trim()) {
+					throw new Error("Cannot restart configured external cs-cloud baseUrl")
+				}
+			},
+			run: () => this.doRestartServer("restartServer"),
+		})
+	}
+
+	private async runConnectionRefreshOperation(options: CsCloudConnectionRefreshOperation): Promise<string> {
 		if (this.startupFailureIsUninstallCsc) {
 			throw new Error(this.startupFailureReason ?? "csc is not installed")
 		}
 
-		this.log(0, "restart", "Starting restart...")
+		options.validate?.()
+
+		this.log(0, options.logBranch, options.startMessage)
+		this.resetRuntimeStateForConnectionRefresh()
+		this.operationPromise = options.run()
+
+		try {
+			const url = await this.operationPromise
+			this.state = "running"
+			this.startupFailureIsUninstallCsc = false
+			this.startWatching()
+			this.startHealthCheck()
+			this.log(0, options.logBranch, `✓ ${options.successMessage} → ${url}`)
+			return url
+		} catch (err) {
+			this.state = "error"
+			this.startupFailureReason = err instanceof Error ? err.message : String(err)
+			this.startupFailureIsUninstallCsc = isUninstallCscError(err)
+			this.log(0, options.logBranch, `✗ ${options.operationLabel} failed: ${this.startupFailureReason}`)
+			throw err
+		} finally {
+			this.operationPromise = undefined
+		}
+	}
+
+	private resetRuntimeStateForConnectionRefresh(): void {
 		this.stopWatching()
 		this.stopHealthCheck()
 		this.childProcess = undefined
@@ -206,26 +273,6 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 		this.lastCrashReason = undefined
 		this.baseUrl = undefined
 		this.operationPromise = undefined
-
-		this.operationPromise = this.doEnsureStarted()
-
-		try {
-			const url = await this.operationPromise
-			this.state = "running"
-			this.startupFailureIsUninstallCsc = false
-			this.startWatching()
-			this.startHealthCheck()
-			this.log(0, "restart", `✓ Restart successful → ${url}`)
-			return url
-		} catch (err) {
-			this.state = "error"
-			this.startupFailureReason = err instanceof Error ? err.message : String(err)
-			this.startupFailureIsUninstallCsc = isUninstallCscError(err)
-			this.log(0, "restart", `✗ Restart failed: ${this.startupFailureReason}`)
-			throw err
-		} finally {
-			this.operationPromise = undefined
-		}
 	}
 
 	dispose(): void {
@@ -262,6 +309,44 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 			await sleep(1000)
 		}
 		return undefined
+	}
+
+	private async doRestartServer(logBranch: string): Promise<string> {
+		if (fs.existsSync(this.bundledBinPath)) {
+			this.processOwner = "extension"
+			this.connectionSource = "bundledBinary"
+			this.log(0, logBranch, `Executing bundled restart: ${this.bundledBinPath} restart`)
+			await this.execCapture(this.bundledBinPath, ["restart"], 30_000, true)
+			return this.waitForRestartReady()
+		}
+
+		let cscCliPath = ""
+		try {
+			const config = getAssistantUIConfig()
+			cscCliPath = await which(config.defaultCli)
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err)
+			const _err = new Error(
+				`${msg}\nInstall command: npm install @costrict/csc -g\nAfter installing csc, run: csc cloud restart`,
+			)
+			// @ts-ignore
+			_err["__IS_UNINSTALL_CSC_ERROR__"] = true
+			throw _err
+		}
+
+		this.processOwner = "external"
+		this.connectionSource = "cliRestart"
+		this.log(0, logBranch, `Executing CLI restart: ${cscCliPath} cloud restart`)
+		await this.execCapture(cscCliPath, ["cloud", "restart"], 30_000, true)
+		return this.waitForRestartReady()
+	}
+
+	private async waitForRestartReady(): Promise<string> {
+		const url = await this.waitForServerUrlFile(this.RESTART_READY_TIMEOUT)
+		if (!url) {
+			throw new Error("cs-cloud restart timed out waiting for server_url")
+		}
+		return url
 	}
 
 	private startWatching(): void {
@@ -347,22 +432,22 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 		this.stopHealthCheck()
 		this.lastCrashReason = reason
 
-		if (this.ownership === "owned" && this.autoRestartCount < this.MAX_AUTO_RESTARTS) {
-			this.autoRestartCount++
-			const delay = 5000 * Math.pow(2, this.autoRestartCount - 1)
+		if (this.processOwner === "extension" && this.autoReconnectCount < this.MAX_AUTO_RECONNECTS) {
+			this.autoReconnectCount++
+			const delay = 5000 * Math.pow(2, this.autoReconnectCount - 1)
 			this.log(
 				0,
 				"crash",
-				`Auto-restart (${this.autoRestartCount}/${this.MAX_AUTO_RESTARTS}), retrying in ${delay}ms`,
+				`Auto-reconnect (${this.autoReconnectCount}/${this.MAX_AUTO_RECONNECTS}), retrying in ${delay}ms`,
 			)
 
 			setTimeout(async () => {
 				try {
-					await this.restart()
-					this.autoRestartCount = 0
-					this.log(0, "crash", "Auto-restart succeeded")
+					await this.reconnect()
+					this.autoReconnectCount = 0
+					this.log(0, "crash", "Auto-reconnect succeeded")
 				} catch (err) {
-					this.log(0, "crash", `Auto-restart failed: ${err instanceof Error ? err.message : String(err)}`)
+					this.log(0, "crash", `Auto-reconnect failed: ${err instanceof Error ? err.message : String(err)}`)
 					this.state = "error"
 					this.emit("crashed", { reason: this.lastCrashReason ?? reason })
 				}
@@ -370,7 +455,7 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 			return
 		}
 
-		this.autoRestartCount = 0
+		this.autoReconnectCount = 0
 		if (this.state !== "error") {
 			this.state = "error"
 			this.emit("crashed", { reason })
@@ -432,7 +517,7 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 		}
 	}
 
-	private execCapture(command: string, args: string[], timeoutMs: number): Promise<string> {
+	private execCapture(command: string, args: string[], timeoutMs: number, rejectOnNonZero = false): Promise<string> {
 		return new Promise((resolve, reject) => {
 			const child = crossSpawn(command, args, {
 				env: { ...process.env },
@@ -452,11 +537,16 @@ export class CsCloudService extends EventEmitter implements vscode.Disposable {
 			child.stdout?.on("data", (d) => chunks.push(String(d)))
 			child.stderr?.on("data", (d) => chunks.push(String(d)))
 
-			child.on("close", () => {
+			child.on("close", (code) => {
 				if (settled) return
 				settled = true
 				clearTimeout(timer)
-				resolve(stripAnsi(chunks.join("")))
+				const output = stripAnsi(chunks.join(""))
+				if (rejectOnNonZero && typeof code === "number" && code !== 0) {
+					reject(new Error(`Command failed (${code}): ${command} ${args.join(" ")}\n${output}`))
+					return
+				}
+				resolve(output)
 			})
 
 			child.on("error", (err) => {

--- a/src/core/cs-cloud/extension/html.ts
+++ b/src/core/cs-cloud/extension/html.ts
@@ -609,7 +609,7 @@ export function getCrashedHtml(reason?: string): string {
       const btn = document.getElementById("restart-btn");
       btn.disabled = true;
       btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="animation:spin 1s linear infinite"><style>@keyframes spin{to{transform:rotate(360deg)}}</style><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg> ' + I18N.connecting;
-      vscode.postMessage({ type: "restartCsCloud" });
+      vscode.postMessage({ type: "reconnectCsCloud" });
     }
 
     function handleSwitchToClassic() {
@@ -621,7 +621,7 @@ export function getCrashedHtml(reason?: string): string {
     }
 
     window.addEventListener("message", (e) => {
-      if (e.data?.type === "restartFailed") {
+      if (e.data?.type === "reconnectFailed") {
         const btn = document.getElementById("restart-btn");
         btn.disabled = false;
         btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 12"/></svg> ' + I18N.reconnect;
@@ -961,6 +961,10 @@ export function getAssistantUIStaticHtml(
               v.postMessage({ type: "openDiff", path: e.data.path, patch: e.data.patch });
               return;
             }
+            if (e.data?.type === "restartCsCloudServer") {
+              v.postMessage({ type: "restartCsCloudServer" });
+              return;
+            }
             if (e.data?.type === "executeCommand" && e.data.command) {
               v.postMessage({ type: "executeCommand", command: e.data.command });
               return;
@@ -1170,6 +1174,10 @@ export function getAssistantUIIframeHtml(
           vscodeApi.postMessage({ type: "openDiff", path: event.data.path, patch: event.data.patch });
           return;
         }
+        if (event.data?.type === "restartCsCloudServer") {
+          vscodeApi.postMessage({ type: "restartCsCloudServer" });
+          return;
+        }
         if (event.data?.type === "executeCommand" && event.data.command) {
           vscodeApi.postMessage({ type: "executeCommand", command: event.data.command });
           return;
@@ -1203,6 +1211,11 @@ export function getAssistantUIIframeHtml(
         return;
       }
       if (event.data?.type === "quotaResult") {
+        if (frame?.contentWindow) {
+          frame.contentWindow.postMessage(event.data, frameOrigin);
+        }
+      }
+      if (event.data?.type === "restartCsCloudServerFailed") {
         if (frame?.contentWindow) {
           frame.contentWindow.postMessage(event.data, frameOrigin);
         }

--- a/src/core/cs-cloud/extension/sidebarProvider.ts
+++ b/src/core/cs-cloud/extension/sidebarProvider.ts
@@ -201,19 +201,36 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 					this.cachedHtml = undefined
 					await this.loadContent(webviewView)
 				}
-				if (message.type === "restartCsCloud") {
+				if (message.type === "reconnectCsCloud") {
 					if (this.csCloudService.startupFailureIsUninstallCsc) {
 						return
 					}
 					try {
-						await this.csCloudService.restart()
+						await this.csCloudService.reconnect()
 						this.cachedHtml = undefined
 						await this.loadContent(this.view!)
 					} catch (err) {
 						const reason = err instanceof Error ? err.message : String(err)
-						this.outputChannel.appendLine(`[AssistantUI] Restart cs-cloud failed: ${reason}`)
+						this.outputChannel.appendLine(`[AssistantUI] Reconnect cs-cloud failed: ${reason}`)
 						this.view?.webview.postMessage({
-							type: "restartFailed",
+							type: "reconnectFailed",
+							reason,
+						})
+					}
+				}
+				if (message.type === "restartCsCloudServer") {
+					if (this.csCloudService.startupFailureIsUninstallCsc) {
+						return
+					}
+					try {
+						await this.csCloudService.restartServer()
+						this.cachedHtml = undefined
+						await this.loadContent(this.view!)
+					} catch (err) {
+						const reason = err instanceof Error ? err.message : String(err)
+						this.outputChannel.appendLine(`[AssistantUI] Restart cs-cloud server failed: ${reason}`)
+						this.view?.webview.postMessage({
+							type: "restartCsCloudServerFailed",
 							reason,
 						})
 					}
@@ -782,7 +799,7 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
         btn.disabled = true;
         btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="animation:spin 1s linear infinite"><style>@keyframes spin{to{transform:rotate(360deg)}}</style><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg> ' + I18N.starting;
       }
-      vscode.postMessage({ type: "restartCsCloud" });
+      vscode.postMessage({ type: "reconnectCsCloud" });
     }
 
     function handleSwitchToClassic() {
@@ -796,7 +813,7 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
     }
 
     window.addEventListener("message", (e) => {
-      if (e.data?.type === "restartFailed") {
+      if (e.data?.type === "reconnectFailed") {
         const btn = document.getElementById("restart-btn");
         if (btn) {
           btn.disabled = false;
@@ -817,13 +834,26 @@ export class AssistantUISidebarProvider implements vscode.WebviewViewProvider {
 </html>`
 	}
 
-	/** Restart entry for command palette. */
-	async restartCsCloud(): Promise<void> {
+	/** Reconnect/retry entry for command palette and error-page retry. */
+	async reconnectCsCloud(): Promise<void> {
 		if (this.csCloudService.startupFailureIsUninstallCsc) {
 			throw new Error(this.csCloudService.startupFailureReason ?? t("common:csCloud.error.cscNotInstalled"))
 		}
 
-		await this.csCloudService.restart()
+		await this.csCloudService.reconnect()
+		this.cachedHtml = undefined
+		if (this.view) {
+			await this.loadContent(this.view)
+		}
+	}
+
+	/** Server-process restart entry for command palette. */
+	async restartCsCloudServer(): Promise<void> {
+		if (this.csCloudService.startupFailureIsUninstallCsc) {
+			throw new Error(this.csCloudService.startupFailureReason ?? t("common:csCloud.error.cscNotInstalled"))
+		}
+
+		await this.csCloudService.restartServer()
 		this.cachedHtml = undefined
 		if (this.view) {
 			await this.loadContent(this.view)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,17 +261,33 @@ export async function activate(context: vscode.ExtensionContext) {
 			}),
 		)
 
-		// 注册 restart 命令（命令面板 + 错误页按钮）
+		// 注册 reconnect/retry 命令（命令面板 + 错误页按钮）
 		context.subscriptions.push(
-			vscode.commands.registerCommand(`${Package.commandIDPrefix}.restartCsCloud`, async () => {
+			vscode.commands.registerCommand(`${Package.commandIDPrefix}.reconnectCsCloud`, async () => {
 				try {
-					await assistantProvider.restartCsCloud()
+					await assistantProvider.reconnectCsCloud()
 				} catch (err) {
 					outputChannel.appendLine(
-						`[cs-cloud] restart failed: ${err instanceof Error ? err.message : String(err)}`,
+						`[cs-cloud] reconnect failed: ${err instanceof Error ? err.message : String(err)}`,
 					)
 					vscode.window.showErrorMessage(
-						`重启 cs-cloud 失败: ${err instanceof Error ? err.message : String(err)}`,
+						`重新连接 cs-cloud 失败: ${err instanceof Error ? err.message : String(err)}`,
+					)
+				}
+			}),
+		)
+
+		// 注册 server restart 命令（独立于 reconnect/retry，不影响错误页按钮语义）
+		context.subscriptions.push(
+			vscode.commands.registerCommand(`${Package.commandIDPrefix}.restartCsCloudServer`, async () => {
+				try {
+					await assistantProvider.restartCsCloudServer()
+				} catch (err) {
+					outputChannel.appendLine(
+						`[cs-cloud] server restart failed: ${err instanceof Error ? err.message : String(err)}`,
+					)
+					vscode.window.showErrorMessage(
+						`重启 cs-cloud 服务失败: ${err instanceof Error ? err.message : String(err)}`,
 					)
 				}
 			}),

--- a/src/package.json
+++ b/src/package.json
@@ -139,8 +139,13 @@
 				"icon": "$(account)"
 			},
 			{
-				"command": "costrict.restartCsCloud",
-				"title": "CoStrict: Restart CoStrict Cloud",
+				"command": "costrict.reconnectCsCloud",
+				"title": "CoStrict: Reconnect CoStrict Cloud",
+				"category": "%configuration.title%"
+			},
+			{
+				"command": "costrict.restartCsCloudServer",
+				"title": "CoStrict: Restart CoStrict Cloud Server",
 				"category": "%configuration.title%"
 			},
 			{


### PR DESCRIPTION
### Related GitHub Issue

Closes: #

### Description

将 cs-cloud 的"重启"语义拆分为两条独立路径，并清理相关命名：

- 将原 `restart()`（重新走发现流程）重命名为 `reconnect()`，语义为"重连/重试"，命令面板与错误页重试按钮均指向 reconnect。
- 新增 `restartServer()`：真正重启 cs-cloud 服务进程。优先使用捆绑二进制执行 `restart`，缺失时回退到全局 `csc cloud restart`，并通过 `server_url` 文件就绪超时（30s）判定结果；对配置了 `baseUrl` 的外部实例拒绝执行。
- 重命名内部状态枚举：`ownership` (`owned`/`unmanaged`) → `processOwner` (`extension`/`external`)；`source` (`spawned`/`detected`/`configuredBaseUrl`) → `connectionSource` (`bundledBinary`/`serverUrlFile`/`cliStatus`/`cliRestart`/`configuredBaseUrl`)，更清晰地表达"谁拥有进程"与"连接从何而来"。
- `autoRestartCount` → `autoReconnectCount`，崩溃自愈逻辑随之走 `reconnect()`。
- Webview 消息类型同步：`restartCsCloud` → `reconnectCsCloud`、`restartFailed` → `reconnectFailed`，并新增 iframe 与扩展宿主之间的 `restartCsCloudServer` / `restartCsCloudServerFailed` 消息转发。
- `execCapture` 新增 `rejectOnNonZero` 选项，用于在服务重启时对非零退出码报错。

### Test Procedure

- 更新了 `assistant-ui-cscloud-service.spec.ts` 与 `assistant-ui-panel.spec.ts` 单测，覆盖：reconnect 不触发 spawn、restartServer 分别命中捆绑二进制与全局 CLI、configured baseUrl 下 reconnect 行为及 restartServer 被拒绝、iframe 与宿主间的 `restartCsCloudServer` 消息转发。
- 本地验证功能正常，`npm run lint` 通过。

### Type of Change

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [x] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [ ] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to follow the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

本次为后端/扩展逻辑改动，无 UI 视觉变化。

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

无。

### Get in Touch

-
