### PR TITLE
fix: reconcile stale startup tokens against auth.json

### DIFF
--- a/src/core/costrict/activate.ts
+++ b/src/core/costrict/activate.ts
@@ -79,6 +79,19 @@ async function initialize(provider: ClineProvider, logger: ILogger) {
 	loadLocalLanguageExtensions()
 }
 
+const prepareCompletionRuntimeAuth = (
+	tokens: { access_token: string; refresh_token: string },
+	provider: ClineProvider,
+) => {
+	void writeCostrictRuntimeAuth(tokens.access_token, tokens.refresh_token)
+		.then(() => ensureCompletionRuntimeReady())
+		.catch((error) => {
+			provider.log(
+				`Failed to prepare completion runtime on startup: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		})
+}
+
 /**
  * Entry function when the ZGSM extension is activated
  */
@@ -127,24 +140,21 @@ export async function activate(
 
 	let loginTip = () => {}
 	try {
-		const isLoggedIn = await costrictAuthService.checkLoginStatusOnStartup()
+		const startupAuth = await costrictAuthService.getStartupAuthTokens()
 
-		if (isLoggedIn) {
-			costrictAuthService.getTokens().then(async (tokens) => {
-				if (!tokens) {
-					return
-				}
-				provider.log(`Login status detected at plugin startup: valid (${tokens.state})`)
-				void writeCostrictRuntimeAuth(tokens.access_token, tokens.refresh_token)
-					.then(() => ensureCompletionRuntimeReady())
-					.catch((error) => {
-						provider.log(
-							`Failed to prepare completion runtime on startup: ${error instanceof Error ? error.message : String(error)}`,
-						)
-					})
-				costrictAuthService.startTokenRefresh(tokens.refresh_token, getClientId(), tokens.state)
-				costrictAuthService.updateUserInfo(tokens.access_token)
-			})
+		if (startupAuth) {
+			const { tokens, source } = startupAuth
+			provider.log(`Login status detected at plugin startup: valid (${tokens.state})`)
+
+			if (source === "file") {
+				provider.log("Startup reconciliation: adopted fresher tokens from auth.json")
+				await costrictAuthService.saveTokens(tokens)
+			} else {
+				prepareCompletionRuntimeAuth(tokens, provider)
+			}
+
+			costrictAuthService.startTokenRefresh(tokens.refresh_token, getClientId(), tokens.state)
+			costrictAuthService.updateUserInfo(tokens.access_token)
 		} else {
 			loginTip = () => {
 				costrictAuthService.getTokens().then(async (tokens) => {

--- a/src/core/costrict/auth/authService.test.ts
+++ b/src/core/costrict/auth/authService.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// jwt-decode is NOT mocked: we feed it real (unsigned) JWTs so the
+// refresh_token expiry logic in isRefreshTokenValid is exercised for real.
+const fakeJwt = (exp: number) => {
+	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url")
+	const payload = Buffer.from(JSON.stringify({ iat: 1, exp })).toString("base64url")
+	return `${header}.${payload}.sig`
+}
+
+const mocks = vi.hoisted(() => ({
+	getTokens: vi.fn(),
+	readCostrictAccessToken: vi.fn(),
+}))
+
+vi.mock("./authStorage", () => ({
+	CostrictAuthStorage: {
+		getInstance: () => ({ getTokens: mocks.getTokens }),
+	},
+}))
+
+vi.mock("../runtime-config", () => ({
+	readCostrictAccessToken: mocks.readCostrictAccessToken,
+}))
+
+vi.mock("./authApi", () => ({
+	CostrictAuthApi: { getInstance: () => ({}) },
+}))
+
+vi.mock("./authConfig", () => ({
+	CostrictAuthConfig: { getInstance: () => ({}) },
+}))
+
+vi.mock("./ipc/client", () => ({
+	sendCostrictLogout: vi.fn(),
+}))
+
+vi.mock("../auto-complete", () => ({
+	CompletionStatusBar: { getInstance: () => ({ complete: () => {} }) },
+}))
+
+vi.mock("../../../i18n", () => ({
+	t: (key: string) => key,
+}))
+
+import { CostrictAuthService } from "./authService"
+
+const futureExp = Math.floor(Date.now() / 1000) + 3600
+const pastExp = Math.floor(Date.now() / 1000) - 3600
+const validRefresh = fakeJwt(futureExp)
+const expiredRefresh = fakeJwt(pastExp)
+
+describe("CostrictAuthService.checkLoginStatusOnStartup", () => {
+	beforeEach(() => {
+		mocks.getTokens.mockReset()
+		mocks.readCostrictAccessToken.mockReset()
+		CostrictAuthService._resetForTesting()
+		CostrictAuthService.setProvider({} as any)
+	})
+
+	it("returns true when SecretStorage has both tokens and a valid refresh_token", async () => {
+		mocks.getTokens.mockResolvedValue({
+			access_token: "access",
+			refresh_token: validRefresh,
+			state: "s",
+		})
+		mocks.readCostrictAccessToken.mockReturnValue(null)
+
+		expect(await CostrictAuthService.getInstance().checkLoginStatusOnStartup()).toBe(true)
+	})
+
+	it("recovers via auth.json when SecretStorage refresh_token is expired", async () => {
+		mocks.getTokens.mockResolvedValue({
+			access_token: "access",
+			refresh_token: expiredRefresh,
+			state: "s",
+		})
+		mocks.readCostrictAccessToken.mockReturnValue({
+			access_token: "access",
+			refresh_token: validRefresh,
+		})
+
+		expect(await CostrictAuthService.getInstance().checkLoginStatusOnStartup()).toBe(true)
+	})
+
+	it("returns auth.json tokens with the local state when auth.json wins", async () => {
+		mocks.getTokens.mockResolvedValue({
+			access_token: "old-access",
+			refresh_token: expiredRefresh,
+			state: "local-state",
+		})
+		mocks.readCostrictAccessToken.mockReturnValue({
+			access_token: "file-access",
+			refresh_token: validRefresh,
+		})
+
+		expect(await CostrictAuthService.getInstance().getStartupAuthTokens()).toEqual({
+			source: "file",
+			tokens: {
+				access_token: "file-access",
+				refresh_token: validRefresh,
+				state: "local-state",
+			},
+		})
+	})
+
+	it("returns false when SecretStorage has refresh but NO access_token (stuck-state guard)", async () => {
+		// Only a refresh_token is not enough: activate.ts cannot build a usable
+		// pair from it, so reporting logged-in would leave the user stuck without
+		// a re-auth path. Both tokens from the same source are required.
+		mocks.getTokens.mockResolvedValue({
+			access_token: "",
+			refresh_token: validRefresh,
+			state: "s",
+		})
+		mocks.readCostrictAccessToken.mockReturnValue(null)
+
+		expect(await CostrictAuthService.getInstance().checkLoginStatusOnStartup()).toBe(false)
+	})
+
+	it("returns false when auth.json has refresh but NO access_token and SecretStorage is unusable", async () => {
+		mocks.getTokens.mockResolvedValue(null)
+		mocks.readCostrictAccessToken.mockReturnValue({
+			access_token: "",
+			refresh_token: validRefresh,
+		})
+
+		expect(await CostrictAuthService.getInstance().checkLoginStatusOnStartup()).toBe(false)
+	})
+
+	it("returns false when auth.json is valid but no local state is available", async () => {
+		mocks.getTokens.mockResolvedValue(null)
+		mocks.readCostrictAccessToken.mockReturnValue({
+			access_token: "access",
+			refresh_token: validRefresh,
+		})
+
+		expect(await CostrictAuthService.getInstance().checkLoginStatusOnStartup()).toBe(false)
+	})
+
+	it("returns false when neither source has a usable token pair", async () => {
+		mocks.getTokens.mockResolvedValue(null)
+		mocks.readCostrictAccessToken.mockReturnValue(null)
+
+		expect(await CostrictAuthService.getInstance().checkLoginStatusOnStartup()).toBe(false)
+	})
+
+	it("returns false when both refresh_tokens are expired", async () => {
+		mocks.getTokens.mockResolvedValue({
+			access_token: "access",
+			refresh_token: expiredRefresh,
+			state: "s",
+		})
+		mocks.readCostrictAccessToken.mockReturnValue({
+			access_token: "access",
+			refresh_token: expiredRefresh,
+		})
+
+		expect(await CostrictAuthService.getInstance().checkLoginStatusOnStartup()).toBe(false)
+	})
+})

--- a/src/core/costrict/auth/authService.ts
+++ b/src/core/costrict/auth/authService.ts
@@ -10,10 +10,19 @@ import { joinUrl } from "../../../utils/joinUrl"
 import { CostrictAuthStatus, CostrictAuthTokens, CostrictLoginState, LoginTokenResponse } from "./types"
 import { generateNewSessionClientId, getClientId } from "../../../utils/getClientId"
 import { sendCostrictLogout } from "./ipc/client"
+import { readCostrictAccessToken } from "../runtime-config"
+import { pickFresher, type CostrictTokenPair } from "../runtime-config/pickFresher"
 import { CompletionStatusBar } from "../auto-complete"
 import { t } from "../../../i18n"
 
 let _loginState = ""
+
+export type CostrictStartupAuthSource = "secret" | "file"
+
+export interface CostrictStartupAuthTokens {
+	tokens: CostrictAuthTokens
+	source: CostrictStartupAuthSource
+}
 
 export class CostrictAuthService {
 	private static instance: CostrictAuthService
@@ -298,21 +307,82 @@ export class CostrictAuthService {
 	}
 
 	/**
-	 * Check login status on plugin startup
+	 * Resolve the token pair that should be used during plugin startup.
+	 *
+	 * SecretStorage owns the local `state`; auth.json may own fresher tokens after
+	 * an external runtime/CLI/other-window refresh. Returning the final token set
+	 * here keeps activate.ts focused on startup side effects instead of duplicating
+	 * storage reads and freshness checks.
+	 */
+	async getStartupAuthTokens(): Promise<CostrictStartupAuthTokens | null> {
+		const secretTokens = await this.getStoredTokensForStartup()
+		const secretPair = this.toValidTokenPair(secretTokens)
+		const filePair = this.readValidFileTokenPair()
+		const winner = pickFresher(secretPair, filePair)
+
+		if (!winner || !secretTokens?.state) {
+			return null
+		}
+
+		if (filePair && winner === filePair) {
+			return {
+				source: "file",
+				tokens: { ...filePair, state: secretTokens.state },
+			}
+		}
+
+		if (!secretPair) {
+			return null
+		}
+
+		return {
+			source: "secret",
+			tokens: { ...secretPair, state: secretTokens.state },
+		}
+	}
+
+	/**
+	 * Check login status on plugin startup.
 	 */
 	async checkLoginStatusOnStartup(): Promise<boolean> {
+		return (await this.getStartupAuthTokens()) !== null
+	}
+
+	private async getStoredTokensForStartup(): Promise<CostrictAuthTokens | null> {
 		try {
-			const tokens = await CostrictAuthStorage.getInstance().getTokens()
-
-			if (!tokens?.access_token || !tokens?.refresh_token) {
-				return false
-			}
-
-			const jwt = jwtDecode(tokens?.refresh_token) as any
-
-			return jwt.exp * 1000 > Date.now()
+			return await CostrictAuthStorage.getInstance().getTokens()
 		} catch (error) {
 			console.error("Failed to check login status on startup:", error)
+			return null
+		}
+	}
+
+	private readValidFileTokenPair(): CostrictTokenPair | null {
+		try {
+			return this.toValidTokenPair(readCostrictAccessToken())
+		} catch {
+			return null
+		}
+	}
+
+	private toValidTokenPair(
+		tokens?: { access_token?: string; refresh_token?: string } | null,
+	): CostrictTokenPair | null {
+		if (!tokens?.access_token || !tokens.refresh_token || !this.isRefreshTokenValid(tokens.refresh_token)) {
+			return null
+		}
+
+		return {
+			access_token: tokens.access_token,
+			refresh_token: tokens.refresh_token,
+		}
+	}
+
+	private isRefreshTokenValid(refreshToken: string): boolean {
+		try {
+			const jwt = jwtDecode(refreshToken) as any
+			return jwt.exp * 1000 > Date.now()
+		} catch {
 			return false
 		}
 	}

--- a/src/core/costrict/auth/authStorage.test.ts
+++ b/src/core/costrict/auth/authStorage.test.ts
@@ -62,6 +62,7 @@ describe("CostrictAuthStorage.saveTokens", () => {
 			},
 			setValue: vi.fn(),
 			upsertProviderProfile: vi.fn().mockResolvedValue(undefined),
+			log: vi.fn(),
 		}
 
 		CostrictAuthStorage.setProvider(mockProvider)
@@ -81,5 +82,34 @@ describe("CostrictAuthStorage.saveTokens", () => {
 
 		expect(writeCostrictRuntimeAuth).toHaveBeenCalledWith(newTokens.access_token, newTokens.refresh_token)
 		expect(ensureCompletionRuntimeReady).toHaveBeenCalledTimes(1)
+	})
+
+	it("still persists when only the access_token changed (refresh unchanged)", async () => {
+		// refresh_token is identical to the stored value. The dedup guard must
+		// only no-op when BOTH tokens match, otherwise a rotated access_token
+		// would be silently dropped.
+		const rotatedAccess = {
+			access_token: "new-access-token",
+			refresh_token: "old-refresh-token",
+			state: "new-state",
+		}
+
+		await CostrictAuthStorage.getInstance().saveTokens(rotatedAccess as any)
+
+		expect(writeCostrictRuntimeAuth).toHaveBeenCalledWith(rotatedAccess.access_token, rotatedAccess.refresh_token)
+		expect(ensureCompletionRuntimeReady).toHaveBeenCalledTimes(1)
+	})
+
+	it("is a no-op when both access and refresh tokens match the stored values", async () => {
+		const sameTokens = {
+			access_token: "old-access-token",
+			refresh_token: "old-refresh-token",
+			state: "old-state",
+		}
+
+		await CostrictAuthStorage.getInstance().saveTokens(sameTokens as any)
+
+		expect(writeCostrictRuntimeAuth).not.toHaveBeenCalled()
+		expect(ensureCompletionRuntimeReady).not.toHaveBeenCalled()
 	})
 })

--- a/src/core/costrict/auth/authStorage.ts
+++ b/src/core/costrict/auth/authStorage.ts
@@ -29,7 +29,7 @@ export class CostrictAuthStorage {
 			return
 		}
 		if (
-			tokens.access_token === state.apiConfiguration.costrictAccessToken ||
+			tokens.access_token === state.apiConfiguration.costrictAccessToken &&
 			tokens.refresh_token === state.apiConfiguration.costrictRefreshToken
 		) {
 			CostrictAuthStorage.clineProvider?.log(

--- a/src/core/costrict/runtime-config/index.ts
+++ b/src/core/costrict/runtime-config/index.ts
@@ -12,6 +12,10 @@ import { CostrictAuthConfig } from "../auth/authConfig"
 import { getClientId } from "../../../utils/getClientId"
 import { createLogger } from "../../../utils/logger"
 import { Package } from "../../../shared/package"
+import { pickFresher } from "./pickFresher"
+
+export { pickFresher }
+export type { CostrictTokenPair } from "./pickFresher"
 
 export interface CostrictWellKnownService {
 	name: string
@@ -216,6 +220,33 @@ export const ensureCompletionRuntimeReady = async (): Promise<void> => {
 }
 
 export const writeCostrictRuntimeAuth = async (accessToken: string, refreshToken: string) => {
+	// Guard: don't clobber a fresher token that an external process
+	// (completion-agent runtime, CLI, another window) has written to auth.json.
+	// After a window reload SecretStorage may hold a stale value; without this
+	// guard every reload would roll back the external refresh. The comparison
+	// covers both refresh and access tokens, so an access-only rotation on disk
+	// is protected too.
+	try {
+		const existing = readCostrictAccessToken()
+		if (existing?.refresh_token) {
+			const incoming = { access_token: accessToken, refresh_token: refreshToken }
+			const onDisk = {
+				access_token: existing.access_token ?? "",
+				refresh_token: existing.refresh_token,
+			}
+			// `pickFresher` returns the on-disk reference only when it is strictly
+			// fresher; on a tie it returns `incoming`, so equal values still write.
+			if (pickFresher(incoming, onDisk) === onDisk) {
+				logger.info(
+					"[runtime-config] skipping auth.json write: on-disk token is fresher than the incoming value",
+				)
+				return
+			}
+		}
+	} catch (error) {
+		logger.info(`[runtime-config] auth.json pre-write check skipped: ${error}`)
+	}
+
 	const homeDir = os.homedir()
 
 	if (!homeDir) {

--- a/src/core/costrict/runtime-config/pickFresher.test.ts
+++ b/src/core/costrict/runtime-config/pickFresher.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+
+import { pickFresher, type CostrictTokenPair } from "./pickFresher"
+
+/**
+ * Build a minimal (unsigned) JWT whose payload carries the given `iat`/`exp`.
+ * jwt-decode only parses structure, it does not verify the signature.
+ */
+const fakeJwt = (iat: number, exp: number): string => {
+	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url")
+	const payload = Buffer.from(JSON.stringify({ iat, exp })).toString("base64url")
+	return `${header}.${payload}.sig`
+}
+
+const pair = (
+	refreshIat: number,
+	refreshExp: number,
+	accessIat: number = refreshIat,
+	accessExp: number = refreshExp,
+): CostrictTokenPair => ({
+	access_token: fakeJwt(accessIat, accessExp),
+	refresh_token: fakeJwt(refreshIat, refreshExp),
+})
+
+describe("pickFresher", () => {
+	it("returns null when both inputs are null", () => {
+		expect(pickFresher(null, null)).toBeNull()
+	})
+
+	it("returns the valid pair when the other is null", () => {
+		const a = pair(1_000, 2_000)
+		expect(pickFresher(a, null)).toBe(a)
+		expect(pickFresher(null, a)).toBe(a)
+	})
+
+	it("prefers the pair with the newer refresh_token `iat`", () => {
+		const older = pair(1_000, 5_000)
+		const newer = pair(2_000, 5_000)
+		expect(pickFresher(older, newer)).toBe(newer)
+		expect(pickFresher(newer, older)).toBe(newer)
+	})
+
+	it("falls back to refresh_token `exp` when `iat` is equal", () => {
+		const shorter = pair(1_000, 2_000)
+		const longer = pair(1_000, 3_000)
+		expect(pickFresher(shorter, longer)).toBe(longer)
+		expect(pickFresher(longer, shorter)).toBe(longer)
+	})
+
+	it("returns the first argument (`a`) for determinism when both are equal", () => {
+		const a = pair(1_000, 2_000)
+		const b = pair(1_000, 2_000)
+		expect(pickFresher(a, b)).toBe(a)
+	})
+
+	it("detects an access-only rotation when refresh_tokens are equal", () => {
+		// refresh unchanged, but access_token was refreshed (newer iat)
+		const staleAccess = pair(1_000, 5_000, 1_000, 2_000)
+		const freshAccess = pair(1_000, 5_000, 2_000, 2_000)
+		expect(pickFresher(staleAccess, freshAccess)).toBe(freshAccess)
+		expect(pickFresher(freshAccess, staleAccess)).toBe(freshAccess)
+	})
+
+	it("prefers a newer refresh_token even when the other side has a newer access_token", () => {
+		// refresh dominates access: newer refresh wins despite older access
+		const newerRefresh = pair(2_000, 5_000, 1_000, 2_000)
+		const olderRefresh = pair(1_000, 5_000, 9_000, 9_000)
+		expect(pickFresher(newerRefresh, olderRefresh)).toBe(newerRefresh)
+		expect(pickFresher(olderRefresh, newerRefresh)).toBe(newerRefresh)
+	})
+
+	it("treats an undecodable refresh_token as the oldest", () => {
+		const valid = pair(1_000, 2_000)
+		const garbage: CostrictTokenPair = { access_token: "x", refresh_token: "not-a-jwt" }
+		expect(pickFresher(valid, garbage)).toBe(valid)
+		expect(pickFresher(garbage, valid)).toBe(valid)
+	})
+
+	it("returns the other side when one side has an empty refresh_token", () => {
+		const valid = pair(1_000, 2_000)
+		const empty: CostrictTokenPair = { access_token: "x", refresh_token: "" }
+		expect(pickFresher(valid, empty)).toBe(valid)
+		expect(pickFresher(empty, valid)).toBe(valid)
+	})
+
+	it("prefers the first argument when neither refresh_token is decodable", () => {
+		// Without a decodable iat/exp on either side there is no basis to switch,
+		// so the current value (`a`) is kept rather than flipping to `b`.
+		const a: CostrictTokenPair = { access_token: "x", refresh_token: "bad-1" }
+		const b: CostrictTokenPair = { access_token: "y", refresh_token: "bad-2" }
+		expect(pickFresher(a, b)).toBe(a)
+	})
+})

--- a/src/core/costrict/runtime-config/pickFresher.ts
+++ b/src/core/costrict/runtime-config/pickFresher.ts
@@ -1,0 +1,105 @@
+import { jwtDecode } from "jwt-decode"
+
+export interface CostrictTokenPair {
+	access_token: string
+	refresh_token: string
+}
+
+interface DecodedJwt {
+	iat: number
+	exp: number
+}
+
+interface TokenScore {
+	refresh: DecodedJwt
+	access: DecodedJwt
+}
+
+const ZERO: DecodedJwt = { iat: 0, exp: 0 }
+
+const decode = (token: string | undefined): DecodedJwt => {
+	if (!token) {
+		return ZERO
+	}
+	try {
+		const jwt = jwtDecode(token) as any
+		return { iat: Number(jwt.iat) || 0, exp: Number(jwt.exp) || 0 }
+	} catch {
+		return ZERO
+	}
+}
+
+/**
+ * Score a token pair. The refresh_token is the primary freshness signal; the
+ * access_token is decoded too so that an access-only rotation (refresh_token
+ * unchanged, access_token refreshed) can still be detected as a tiebreaker.
+ *
+ * Returns null only when the pair is missing or its refresh_token cannot be
+ * decoded — such a pair is treated as the oldest.
+ */
+const scoreToken = (pair: CostrictTokenPair | null): TokenScore | null => {
+	if (!pair?.refresh_token) {
+		return null
+	}
+	try {
+		const rJwt = jwtDecode(pair.refresh_token) as any
+		return {
+			refresh: { iat: Number(rJwt.iat) || 0, exp: Number(rJwt.exp) || 0 },
+			access: decode(pair.access_token),
+		}
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Compare two scores. Refresh_token fields dominate; access_token fields only
+ * break ties, so an access-only rotation is detected without overriding a
+ * genuinely fresher refresh_token. Returns <0 when `a` is older, >0 when newer,
+ * 0 when equal.
+ */
+const compareScore = (a: TokenScore, b: TokenScore): number => {
+	if (a.refresh.iat !== b.refresh.iat) return a.refresh.iat - b.refresh.iat
+	if (a.refresh.exp !== b.refresh.exp) return a.refresh.exp - b.refresh.exp
+	if (a.access.iat !== b.access.iat) return a.access.iat - b.access.iat
+	if (a.access.exp !== b.access.exp) return a.access.exp - b.access.exp
+	return 0
+}
+
+/**
+ * Pick the fresher of two costrict token pairs.
+ *
+ * Used to reconcile `~/.costrict/share/auth.json` (which may be written by an
+ * external process — the completion-agent runtime, the CLI, or another window)
+ * against the value held in VSCode SecretStorage. After a window reload the
+ * SecretStorage value can be stale; this lets the startup flow adopt the
+ * on-disk token instead of clobbering it.
+ *
+ * Comparison order:
+ *   1. refresh_token `iat` — monotonic across refreshes, the primary signal.
+ *   2. refresh_token `exp` — tiebreaker on equal `iat`.
+ *   3. access_token `iat` — detects an access-only rotation.
+ *   4. access_token `exp` — final tiebreaker.
+ *
+ * Returns whichever input is fresher. When the two are equal, `a` is returned
+ * for determinism. A null / undecodable input always loses to a valid one; if
+ * both are null, null is returned.
+ */
+export const pickFresher = (a: CostrictTokenPair | null, b: CostrictTokenPair | null): CostrictTokenPair | null => {
+	const sa = scoreToken(a)
+	const sb = scoreToken(b)
+
+	// Neither side can be scored: we have no basis to switch, so prefer the
+	// first argument (current value) and avoid flipping to an unknown token.
+	// Returns null only when both inputs themselves are null.
+	if (!sa && !sb) {
+		return a ?? b
+	}
+	if (!sa) {
+		return b
+	}
+	if (!sb) {
+		return a
+	}
+	return compareScore(sa, sb) >= 0 ? a : b
+}


### PR DESCRIPTION
### Related GitHub Issue

Closes: # <!-- no linked issue provided -->

### Description

修复插件启动时的 token 对账问题。外部进程（completion-agent 运行时 / CLI / 其他窗口）刷新 token 后会写入 `~/.costrict/share/auth.json`，但窗口重载后 SecretStorage 仍持有旧值，启动流程会反过来用旧 token 覆盖磁盘上更新的 token，导致用户被"回滚"到未刷新状态。

主要改动：
- 新增 `pickFresher`：按 refresh_token 的 `iat`/`exp`（access_token 作为 tiebreaker）比较两个 token pair，选出更新的；支持识别 access-only 轮换。
- `authService.getStartupAuthTokens()`：启动时对账 SecretStorage 与 auth.json，若 auth.json 更新则采用并将其回写到 SecretStorage；`checkLoginStatusOnStartup` 复用该方法，并补充"同源成对"判断，避免只有 refresh_token 时误报已登录而无法重新走登录流程。
- `writeCostrictRuntimeAuth`：写入前检查磁盘是否已存在更新的 token，避免覆盖外部进程更新的值。
- `authStorage.saveTokens` 去重判断由 `||` 改为 `&&`，修复仅 access_token 轮换（refresh 未变）时被误判为"无需写入"而丢弃新 access_token 的 bug。
- 新增 `pickFresher` / `authService` / `authStorage` 单元测试。

### Test Procedure

- 新增单元测试覆盖 `pickFresher` 全部分支、`authService` 启动对账逻辑（含 SecretStorage/auth.json 各自过期、缺失 access_token 等场景）、`authStorage` 去重逻辑（仅 access 变化仍写入 / 两者相同则 no-op）。
- `turbo lint`（`--max-warnings=0`）通过。

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [ ] All tests pass locally (`npm test`).
    - [ ] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

无 UI 变更。

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

- 勾选项说明：`npm test` 全量测试与 `npm run changeset` 本次未执行，对应条目未勾选，留待提交前补充验证；如需我可补跑测试或补 changeset。

### Get in Touch

<!-- Discord username -->