### PR TITLE
Add token-count badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 <img src="https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square" alt="License">
 <img src="https://img.shields.io/badge/platform-VS%20Code%20%7C%20JetBrains-orange?style=flat-square" alt="Platform">
 <img src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square" alt="PRs Welcome">
+<img src="https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/zgsm-ai/costrict" alt="tokens">
 
 </div>
 


### PR DESCRIPTION
Hi! This PR adds one line to the README: a badge showing an estimate of how many LLM tokens this repo weighs. Since this project is the kind of thing people load into an LLM's context window, the number seemed genuinely useful to surface.

Preview: ![tokens](https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/zgsm-ai/costrict)

Full disclosure: I built the free, open-source service behind the badge (https://github.com/rsamf/gittokens), and I'm proposing it to a small, hand-picked set of repos where it seems like a good fit. If it isn't a fit here, please just close this, and I won't resubmit.