### PR TITLE
feat: distinguish authoritative model lists from cache

### DIFF
--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -172,6 +172,8 @@ export interface ExtensionMessage {
 	ollamaModels?: ModelRecord
 	lmStudioModels?: ModelRecord
 	fullResponseData?: ICostrictModelResponseData[]
+	/** Whether a costrictModels payload came directly from a successful provider request. */
+	modelListAuthoritative?: boolean
 	vsCodeLmModels?: { vendor?: string; family?: string; version?: string; id?: string }[]
 	mcpServers?: McpServer[]
 	commits?: GitCommit[]

--- a/src/api/providers/fetchers/__tests__/modelCache.spec.ts
+++ b/src/api/providers/fetchers/__tests__/modelCache.spec.ts
@@ -58,7 +58,7 @@ vi.mock("../../../core/config/ContextProxy", () => ({
 import type { Mock } from "vitest"
 import * as fsSync from "fs"
 import NodeCache from "node-cache"
-import { getModels, getModelsFromCache } from "../modelCache"
+import { getModels, getModelsFromCache, getModelsWithMetadata, refreshModelsWithMetadata } from "../modelCache"
 import { getLiteLLMModels } from "../litellm"
 import { getOpenRouterModels } from "../openrouter"
 import { getRequestyModels } from "../requesty"
@@ -70,6 +70,78 @@ const mockGetRequestyModels = getRequestyModels as Mock<typeof getRequestyModels
 const mockGetCostrictModels = getCostrictModels as Mock<typeof getCostrictModels>
 
 const DUMMY_REQUESTY_KEY = "requesty-key-for-testing"
+
+describe("model list authority metadata", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		const mockCache: any = new NodeCache()
+		mockCache.get.mockReturnValue(undefined)
+		vi.mocked(fsSync.existsSync).mockReturnValue(false)
+	})
+
+	afterEach(() => {
+		const mockCache: any = new NodeCache()
+		mockCache.get.mockReturnValue(undefined)
+	})
+
+	it("marks a direct provider response as authoritative", async () => {
+		const models = {
+			"openrouter/fresh-model": {
+				maxTokens: 8192,
+				contextWindow: 128000,
+				supportsPromptCache: false,
+			},
+		}
+		mockGetOpenRouterModels.mockResolvedValue(models)
+
+		await expect(getModelsWithMetadata({ provider: "openrouter" })).resolves.toEqual({
+			models,
+			authoritative: true,
+		})
+	})
+
+	it("marks a cache hit as non-authoritative", async () => {
+		const models = {
+			"openrouter/cached-model": {
+				maxTokens: 8192,
+				contextWindow: 128000,
+				supportsPromptCache: false,
+			},
+		}
+		const mockCache: any = new NodeCache()
+		mockCache.get.mockReturnValue(models)
+
+		await expect(getModelsWithMetadata({ provider: "openrouter" })).resolves.toEqual({
+			models,
+			authoritative: false,
+		})
+	})
+
+	it("marks refresh fallback data as non-authoritative", async () => {
+		const models = {
+			"costrict/cached-model": {
+				id: "costrict/cached-model",
+				maxTokens: 8192,
+				contextWindow: 128000,
+				supportsPromptCache: false,
+			},
+		}
+		const mockCache: any = new NodeCache()
+		mockCache.get.mockReturnValue(models)
+		mockGetCostrictModels.mockRejectedValue(new Error("API error"))
+
+		await expect(
+			refreshModelsWithMetadata({
+				provider: "costrict",
+				baseUrl: "https://api.example.com",
+				apiKey: "test-api-key",
+			}),
+		).resolves.toEqual({
+			models,
+			authoritative: false,
+		})
+	})
+})
 
 describe("getModels with new GetModelsOptions", () => {
 	beforeEach(() => {

--- a/src/api/providers/fetchers/costrict.ts
+++ b/src/api/providers/fetchers/costrict.ts
@@ -2,7 +2,6 @@ import axios from "axios"
 import { v7 as uuidv7 } from "uuid"
 import { COSTRICT_DEFAULT_HEADERS } from "../../../shared/headers"
 import type { InviteCodeInfo, ICostrictModelResponseData, QuotaInfo } from "@roo-code/types"
-import { readModels } from "./modelCache"
 import { CostrictAuthService } from "../../../core/costrict/auth"
 
 export async function getCostrictModels(
@@ -52,9 +51,7 @@ export async function getCostrictModels(
 			`Error fetching costrictModels from [${requestId}|${baseUrl}/ai-gateway/api/v1/models]:`,
 			error.message,
 		)
-		const modelCache = (await readModels("costrict")) || {}
-
-		return Object.keys(modelCache).map((key) => modelCache[key])
+		throw error
 	}
 }
 

--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -36,9 +36,18 @@ const memoryCache = new NodeCache({ stdTTL: 5 * 60, checkperiod: 5 * 60 })
 // Zod schema for validating ModelRecord structure from disk cache
 const modelRecordSchema = z.record(z.string(), modelInfoSchema)
 
+export interface ModelFetchResult {
+	models: ModelRecord
+	/**
+	 * True only when `models` came directly from a successful provider request.
+	 * Memory/disk cache hits and graceful-degradation fallbacks are never authoritative.
+	 */
+	authoritative: boolean
+}
+
 // Track in-flight refresh requests to prevent concurrent API calls for the same provider
 // This prevents race conditions where multiple calls might overwrite each other's results
-const inFlightRefresh = new Map<RouterName, Promise<ModelRecord>>()
+const inFlightRefresh = new Map<RouterName, Promise<ModelFetchResult>>()
 
 async function writeModels(router: RouterName, data: ModelRecord) {
 	const filename = `${router}_models.json`
@@ -137,7 +146,7 @@ async function fetchModelsFromProvider(options: GetModelsOptions): Promise<Model
  * @param baseUrl - Optional base URL for the provider (currently used only for LiteLLM).
  * @returns The models from the cache or the fetched models.
  */
-export const getModels = async (options: GetModelsOptions): Promise<ModelRecord> => {
+export const getModelsWithMetadata = async (options: GetModelsOptions): Promise<ModelFetchResult> => {
 	const { provider } = options
 	const refreshOnDiskCacheHit = "refreshOnDiskCacheHit" in options && options.refreshOnDiskCacheHit
 	const hadMemoryModels = memoryCache.get<ModelRecord>(provider) != null
@@ -156,7 +165,7 @@ export const getModels = async (options: GetModelsOptions): Promise<ModelRecord>
 						console.error(`[getModels] Background refresh failed for ${provider}:`, error)
 					})
 				}
-				return models
+				return { models, authoritative: false }
 			}
 		}
 		models = await fetchModelsFromProvider(options)
@@ -178,7 +187,7 @@ export const getModels = async (options: GetModelsOptions): Promise<ModelRecord>
 			})
 		}
 
-		return models
+		return { models, authoritative: true }
 	} catch (error) {
 		// Log the error and re-throw it so the caller can handle it (e.g., show a UI message).
 		console.error(`[getModels] Failed to fetch models in modelCache for ${provider}:`, error)
@@ -186,6 +195,9 @@ export const getModels = async (options: GetModelsOptions): Promise<ModelRecord>
 		throw error // Re-throw the original error to be handled by the caller.
 	}
 }
+
+export const getModels = async (options: GetModelsOptions): Promise<ModelRecord> =>
+	(await getModelsWithMetadata(options)).models
 
 /**
  * Force-refresh models from API, bypassing cache.
@@ -196,7 +208,7 @@ export const getModels = async (options: GetModelsOptions): Promise<ModelRecord>
  * @param options - Provider options for fetching models
  * @returns Fresh models from API, or existing cache if refresh yields worse data
  */
-export const refreshModels = async (options: GetModelsOptions): Promise<ModelRecord> => {
+export const refreshModelsWithMetadata = async (options: GetModelsOptions): Promise<ModelFetchResult> => {
 	const { provider } = options
 
 	// Check if there's already an in-flight refresh for this provider
@@ -208,7 +220,7 @@ export const refreshModels = async (options: GetModelsOptions): Promise<ModelRec
 	}
 
 	// Create the refresh promise and track it
-	const refreshPromise = (async (): Promise<ModelRecord> => {
+	const refreshPromise = (async (): Promise<ModelFetchResult> => {
 		try {
 			// Force fresh API fetch - skip getModelsFromCache() check
 			const models = await fetchModelsFromProvider(options)
@@ -226,9 +238,9 @@ export const refreshModels = async (options: GetModelsOptions): Promise<ModelRec
 					existingCacheSize: existingCount,
 				})
 				if (existingCount > 0) {
-					return existingCache!
+					return { models: existingCache!, authoritative: false }
 				} else {
-					return {}
+					return { models: {}, authoritative: false }
 				}
 			}
 
@@ -240,11 +252,11 @@ export const refreshModels = async (options: GetModelsOptions): Promise<ModelRec
 				console.error(`[refreshModels] Error writing ${provider} models to disk:`, err),
 			)
 
-			return models
+			return { models, authoritative: true }
 		} catch (error) {
 			// Log the error for debugging, then return existing cache if available (graceful degradation)
 			console.error(`[refreshModels] Failed to refresh ${provider} models:`, error)
-			return getModelsFromCache(provider) || {}
+			return { models: getModelsFromCache(provider) || {}, authoritative: false }
 		} finally {
 			// Always clean up the in-flight tracking
 			inFlightRefresh.delete(provider)
@@ -256,6 +268,9 @@ export const refreshModels = async (options: GetModelsOptions): Promise<ModelRec
 
 	return refreshPromise
 }
+
+export const refreshModels = async (options: GetModelsOptions): Promise<ModelRecord> =>
+	(await refreshModelsWithMetadata(options)).models
 
 /**
  * Initialize background model cache refresh.
@@ -292,7 +307,7 @@ export async function initializeModelCacheRefresh(): Promise<void> {
 export const flushModels = async (
 	options: GetModelsOptions,
 	refresh: boolean = false,
-	cb?: (v: any) => void,
+	cb?: (models: ModelRecord, metadata: ModelFetchResult) => void,
 ): Promise<void> => {
 	const { provider } = options
 	if (refresh) {
@@ -300,8 +315,8 @@ export const flushModels = async (
 		// This prevents a race condition where getModels() might be called
 		// before refresh completes, avoiding a gap in cache availability
 		// Await the refresh to ensure the cache is updated before returning
-		await refreshModels(options)
-			.then(cb)
+		await refreshModelsWithMetadata(options)
+			.then((result) => cb?.(result.models, result))
 			.catch((error) => {
 				console.log(`[flushModels] Refresh failed for ${provider}:`, error.message)
 			})

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -294,6 +294,7 @@ vi.mock("../../../integrations/misc/extract-text", () => ({
 
 vi.mock("../../../api/providers/fetchers/modelCache", () => ({
 	getModels: vi.fn().mockResolvedValue({}),
+	getModelsWithMetadata: vi.fn().mockResolvedValue({ models: {}, authoritative: false }),
 	flushModels: vi.fn(),
 	getModelsFromCache: vi.fn().mockReturnValue(undefined),
 }))
@@ -368,6 +369,7 @@ vi.mock("../../../integrations/misc/extract-text", () => ({
 
 vi.mock("../../../api/providers/fetchers/modelCache", () => ({
 	getModels: vi.fn().mockResolvedValue({}),
+	getModelsWithMetadata: vi.fn().mockResolvedValue({ models: {}, authoritative: false }),
 	flushModels: vi.fn(),
 	getModelsFromCache: vi.fn().mockReturnValue(undefined),
 }))
@@ -3068,8 +3070,9 @@ describe("ClineProvider - Router Models", () => {
 			},
 		}
 
-		const { getModels } = await import("../../../api/providers/fetchers/modelCache")
+		const { getModels, getModelsWithMetadata } = await import("../../../api/providers/fetchers/modelCache")
 		vi.mocked(getModels).mockResolvedValue(mockModels)
+		vi.mocked(getModelsWithMetadata).mockResolvedValue({ models: mockModels, authoritative: false })
 
 		await messageHandler({ type: "requestRouterModels" })
 
@@ -3090,6 +3093,7 @@ describe("ClineProvider - Router Models", () => {
 			type: "costrictModels",
 			openAiModels: ["model-1", "model-2"],
 			fullResponseData: [mockModels["model-1"], mockModels["model-2"]],
+			modelListAuthoritative: false,
 		})
 
 		// Verify response was sent
@@ -3127,12 +3131,12 @@ describe("ClineProvider - Router Models", () => {
 		const mockModels = {
 			"model-1": { maxTokens: 4096, contextWindow: 8192, description: "Test model", supportsPromptCache: false },
 		}
-		const { getModels } = await import("../../../api/providers/fetchers/modelCache")
+		const { getModels, getModelsWithMetadata } = await import("../../../api/providers/fetchers/modelCache")
+		vi.mocked(getModelsWithMetadata).mockResolvedValue({ models: mockModels, authoritative: false })
 
 		// Mock some providers to succeed and others to fail
-		// Provider order in source: costrict, openrouter, requesty, vercel-ai-gateway, litellm (conditional)
+		// Costrict uses getModelsWithMetadata; remaining providers use getModels.
 		vi.mocked(getModels)
-			.mockResolvedValueOnce(mockModels) // costrict success (first call)
 			.mockResolvedValueOnce(mockModels) // openrouter success
 			.mockRejectedValueOnce(new Error("Requesty API error")) // requesty fail
 			.mockResolvedValueOnce(mockModels) // unbound success
@@ -3146,6 +3150,7 @@ describe("ClineProvider - Router Models", () => {
 			type: "costrictModels",
 			openAiModels: ["model-1"],
 			fullResponseData: [mockModels["model-1"]],
+			modelListAuthoritative: false,
 		})
 
 		// Verify main response includes successful providers and empty objects for failed ones
@@ -3198,8 +3203,9 @@ describe("ClineProvider - Router Models", () => {
 		const mockModels = {
 			"model-1": { maxTokens: 4096, contextWindow: 8192, description: "Test model", supportsPromptCache: false },
 		}
-		const { getModels } = await import("../../../api/providers/fetchers/modelCache")
+		const { getModels, getModelsWithMetadata } = await import("../../../api/providers/fetchers/modelCache")
 		vi.mocked(getModels).mockResolvedValue(mockModels)
+		vi.mocked(getModelsWithMetadata).mockResolvedValue({ models: mockModels, authoritative: false })
 
 		await messageHandler({
 			type: "requestRouterModels",
@@ -3232,10 +3238,9 @@ describe("ClineProvider - Router Models", () => {
 		const mockModels = {
 			"model-1": { maxTokens: 4096, contextWindow: 8192, description: "Test model", supportsPromptCache: false },
 		}
-		const { getModels } = await import("../../../api/providers/fetchers/modelCache")
-		vi.mocked(getModels)
-			.mockResolvedValueOnce(mockModels) // costrict success (first call)
-			.mockResolvedValue(mockModels) // other providers success
+		const { getModels, getModelsWithMetadata } = await import("../../../api/providers/fetchers/modelCache")
+		vi.mocked(getModels).mockResolvedValue(mockModels)
+		vi.mocked(getModelsWithMetadata).mockResolvedValue({ models: mockModels, authoritative: false })
 
 		await messageHandler({ type: "requestRouterModels" })
 
@@ -3251,6 +3256,7 @@ describe("ClineProvider - Router Models", () => {
 			type: "costrictModels",
 			openAiModels: ["model-1"],
 			fullResponseData: [mockModels["model-1"]],
+			modelListAuthoritative: false,
 		})
 
 		// Verify response includes empty object for LiteLLM

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -61,12 +61,13 @@ import type { ModelRecord } from "@roo-code/types"
 
 import { webviewMessageHandler } from "../webviewMessageHandler"
 import type { ClineProvider } from "../ClineProvider"
-import { getModels } from "../../../api/providers/fetchers/modelCache"
+import { getModels, getModelsWithMetadata } from "../../../api/providers/fetchers/modelCache"
 import { getCommands } from "../../../services/command/commands"
 const { openAiCodexOAuthManager } = await import("../../../integrations/openai-codex/oauth")
 const { fetchOpenAiCodexRateLimitInfo } = await import("../../../integrations/openai-codex/rate-limits")
 
 const mockGetModels = getModels as Mock<typeof getModels>
+const mockGetModelsWithMetadata = getModelsWithMetadata as Mock<typeof getModelsWithMetadata>
 const mockGetCommands = vi.mocked(getCommands)
 const mockGetAccessToken = vi.mocked(openAiCodexOAuthManager.getAccessToken)
 const mockGetAccountId = vi.mocked(openAiCodexOAuthManager.getAccountId)
@@ -348,6 +349,10 @@ describe("webviewMessageHandler - requestOllamaModels", () => {
 describe("webviewMessageHandler - requestRouterModels", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		mockGetModelsWithMetadata.mockImplementation(async (options) => ({
+			models: await mockGetModels(options),
+			authoritative: false,
+		}))
 		mockClineProvider.getState = vi.fn().mockResolvedValue({
 			apiConfiguration: {
 				openRouterApiKey: "openrouter-key",
@@ -408,6 +413,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 			type: "costrictModels",
 			openAiModels: ["model-1", "model-2"],
 			fullResponseData: [mockModels["model-1"], mockModels["model-2"]],
+			modelListAuthoritative: false,
 		})
 
 		// Verify response was sent
@@ -425,6 +431,32 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 				poe: {},
 			},
 			values: undefined,
+		})
+	})
+
+	it("marks a direct costrict provider result as authoritative", async () => {
+		const mockModels: ModelRecord = {
+			"model-1": {
+				maxTokens: 4096,
+				contextWindow: 8192,
+				supportsPromptCache: false,
+			},
+		}
+		mockGetModelsWithMetadata.mockResolvedValue({
+			models: mockModels,
+			authoritative: true,
+		})
+
+		await webviewMessageHandler(mockClineProvider, {
+			type: "requestRouterModels",
+			values: { provider: "costrict" },
+		})
+
+		expect(mockClineProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "costrictModels",
+			openAiModels: ["model-1"],
+			fullResponseData: [mockModels["model-1"]],
+			modelListAuthoritative: true,
 		})
 	})
 
@@ -509,6 +541,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 			type: "costrictModels",
 			openAiModels: ["model-1"],
 			fullResponseData: [mockModels["model-1"]],
+			modelListAuthoritative: false,
 		})
 
 		// Verify response includes empty object for LiteLLM
@@ -559,6 +592,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 			type: "costrictModels",
 			fullResponseData: [mockModels["model-1"]],
 			openAiModels: ["model-1"],
+			modelListAuthoritative: false,
 		})
 
 		// Verify error messages were sent for failed providers

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -76,7 +76,12 @@ import {
 	isProviderAllowedForCostrictCodeMode,
 	resolveCostrictCodeModeForMode,
 } from "../../shared/modes"
-import { getModels, flushModels } from "../../api/providers/fetchers/modelCache"
+import {
+	getModels,
+	getModelsWithMetadata,
+	flushModels,
+	type ModelFetchResult,
+} from "../../api/providers/fetchers/modelCache"
 import { GetModelsOptions } from "../../shared/api"
 import { generateSystemPrompt } from "./generateSystemPrompt"
 import { resolveDefaultSaveUri, saveLastExportPath } from "../../utils/export"
@@ -730,7 +735,7 @@ export const webviewMessageHandler = async (
 							baseUrl: provider.getValue("costrictBaseUrl"),
 						},
 						true,
-						(models: ModelRecord) => {
+						(models: ModelRecord, metadata) => {
 							const openAiModels = [] as string[]
 							const fullResponseData = [] as ModelInfo[]
 							for (const [id, value] of Object.entries(models)) {
@@ -741,6 +746,7 @@ export const webviewMessageHandler = async (
 								type: "costrictModels",
 								openAiModels,
 								fullResponseData,
+								modelListAuthoritative: metadata.authoritative,
 							})
 						},
 					)
@@ -1156,7 +1162,7 @@ export const webviewMessageHandler = async (
 				opt.openAiHeaders = apiConfiguration?.openAiHeaders
 			}
 
-			await flushModels(opt, true, (models: ModelRecord) => {
+			await flushModels(opt, true, (models: ModelRecord, metadata) => {
 				if (apiConfiguration?.apiProvider === "costrict") {
 					const openAiModels = [] as string[]
 					const fullResponseData = [] as ModelInfo[]
@@ -1168,6 +1174,7 @@ export const webviewMessageHandler = async (
 						type: "costrictModels",
 						openAiModels,
 						fullResponseData,
+						modelListAuthoritative: metadata.authoritative,
 					})
 				}
 			})
@@ -1295,14 +1302,23 @@ export const webviewMessageHandler = async (
 				: candidates
 
 			// If refresh flag is set and we have a specific provider, flush its cache first
+			let forcedRefreshResult: ModelFetchResult | undefined
 			if (shouldRefresh && providerFilter && modelFetchPromises.length > 0) {
 				const targetCandidate = modelFetchPromises[0]
-				await flushModels(targetCandidate.options, true)
+				await flushModels(targetCandidate.options, true, (_models, metadata) => {
+					forcedRefreshResult = metadata
+				})
 			}
 
 			const results = await Promise.allSettled(
 				modelFetchPromises.map(async ({ key, options }) => {
-					const models = await safeGetModels(options)
+					const result =
+						key === providerFilter && forcedRefreshResult
+							? forcedRefreshResult
+							: key === "costrict"
+								? await getModelsWithMetadata(options)
+								: { models: await safeGetModels(options), authoritative: false }
+					const { models } = result
 
 					if (key === "costrict") {
 						const openAiModels = [] as string[]
@@ -1315,6 +1331,7 @@ export const webviewMessageHandler = async (
 							type: "costrictModels",
 							openAiModels,
 							fullResponseData,
+							modelListAuthoritative: result.authoritative,
 						})
 					}
 

--- a/webview-ui/src/components/settings/ProviderRenderer.tsx
+++ b/webview-ui/src/components/settings/ProviderRenderer.tsx
@@ -136,6 +136,7 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 		switch (message.type) {
 			case "costrictModels": {
 				const { fullResponseData = [] } = message
+				const authoritative = message.modelListAuthoritative === true
 				const newModels = Object.fromEntries(
 					fullResponseData.map((item) => [item.id, { ...(item ?? costrictModels.default) }]),
 				) as Record<string, ModelInfo>
@@ -145,7 +146,7 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 				// The pure rule (and its rationale) lives in ./utils/correctModelSelection.
 				const oldModelIds = Object.keys(previousCostrictModelsRef.current ?? {})
 				const selectedModelId = selectedModelIdRef.current
-				const corrected = getCorrectedCostrictModelId(oldModelIds, newModelIds, selectedModelId)
+				const corrected = getCorrectedCostrictModelId(oldModelIds, newModelIds, selectedModelId, authoritative)
 				// Only the primary costrict selector applies the correction + notice. Other providers
 				// also receive costrictModels pushes (requestRouterModels broadcasts them), and the
 				// message-edit duplicate instance must not fire these global side-effects.
@@ -167,12 +168,16 @@ const ProviderRenderer: React.FC<ProviderRendererProps> = ({
 					})
 				}
 
-				// Preserve the last NON-EMPTY costrict list as the baseline for the next refresh.
-				if (newModelIds.length > 0) {
+				// Only a direct provider response may become the correction baseline.
+				if (authoritative && newModelIds.length > 0) {
 					previousCostrictModelsRef.current = newModels
 				}
 
-				setCostrictModelList(newModels)
+				// Cached data is useful on initial load, but must not replace an authoritative
+				// list already shown in this webview.
+				if (authoritative || previousCostrictModelsRef.current === null) {
+					setCostrictModelList(newModels)
+				}
 				setIsRefreshing(false)
 				break
 			}

--- a/webview-ui/src/components/settings/utils/correctModelSelection.spec.ts
+++ b/webview-ui/src/components/settings/utils/correctModelSelection.spec.ts
@@ -6,44 +6,50 @@ import { getCorrectedCostrictModelId } from "./correctModelSelection"
 
 describe("getCorrectedCostrictModelId", () => {
 	it("returns null when no model is selected", () => {
-		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], undefined)).toBeNull()
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], undefined, true)).toBeNull()
 	})
 
 	it("returns null when the old list is empty (we don't know the server set yet)", () => {
-		expect(getCorrectedCostrictModelId([], ["Auto"], "qwen-max")).toBeNull()
+		expect(getCorrectedCostrictModelId([], ["Auto"], "qwen-max", true)).toBeNull()
 	})
 
 	it("returns null for a custom model that was never in the old list", () => {
-		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], "my-private-model")).toBeNull()
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], "my-private-model", true)).toBeNull()
 	})
 
 	it("returns null when the selected model is still in the new list", () => {
-		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto", "qwen-max"], "qwen-max")).toBeNull()
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto", "qwen-max"], "qwen-max", true)).toBeNull()
 	})
 
 	it("returns Auto when a previously-listed server model was removed and Auto is available", () => {
-		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto", "qwen-plus"], "qwen-max")).toBe("Auto")
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto", "qwen-plus"], "qwen-max", true)).toBe("Auto")
 	})
 
 	it("returns the first new model when Auto is absent from the new list", () => {
-		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["qwen-plus", "qwen-turbo"], "qwen-max")).toBe(
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["qwen-plus", "qwen-turbo"], "qwen-max", true)).toBe(
 			"qwen-plus",
 		)
 	})
 
+	it("returns null when the new list is not authoritative", () => {
+		expect(
+			getCorrectedCostrictModelId(["Auto", "qwen-max"], ["qwen-plus", "qwen-turbo"], "qwen-max", false),
+		).toBeNull()
+	})
+
 	it("returns null when the new list is empty (nothing to fall back to)", () => {
-		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], [], "qwen-max")).toBeNull()
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], [], "qwen-max", true)).toBeNull()
 	})
 
 	it("returns null when the selected model is an empty string", () => {
-		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], "")).toBeNull()
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["Auto"], "", true)).toBeNull()
 	})
 
 	it("returns the sole model when the new list has exactly one element and Auto is absent", () => {
-		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["qwen-plus"], "qwen-max")).toBe("qwen-plus")
+		expect(getCorrectedCostrictModelId(["Auto", "qwen-max"], ["qwen-plus"], "qwen-max", true)).toBe("qwen-plus")
 	})
 
 	it("returns null for a custom model even when the new list is empty (guard order)", () => {
-		expect(getCorrectedCostrictModelId(["Auto"], [], "my-custom")).toBeNull()
+		expect(getCorrectedCostrictModelId(["Auto"], [], "my-custom", true)).toBeNull()
 	})
 })

--- a/webview-ui/src/components/settings/utils/correctModelSelection.ts
+++ b/webview-ui/src/components/settings/utils/correctModelSelection.ts
@@ -5,6 +5,7 @@ import { costrictDefaultModelId } from "@roo-code/types"
  * list was refreshed, and if so, which model id to switch to.
  *
  * Rule (see docs/adr/0001-model-selection-correction.md):
+ * - Skip non-authoritative lists (cache hits and failed-refresh fallbacks).
  * - Skip when the old list is empty — we don't yet know the legitimate server set.
  * - Only correct a "server model": one that WAS in the old list. This protects a
  *   user-typed "custom model" whose id is intentionally absent from the server list.
@@ -18,7 +19,11 @@ export function getCorrectedCostrictModelId(
 	oldModelIds: string[],
 	newModelIds: string[],
 	selectedModelId: string | undefined,
+	authoritative: boolean,
 ): string | null {
+	if (!authoritative) {
+		return null
+	}
 	if (!selectedModelId) {
 		return null
 	}


### PR DESCRIPTION
### Related GitHub Issue

Closes: # <!-- 暂未关联 issue，如有请补充编号 -->

### Description

为模型拉取结果引入 `authoritative` 标记，区分「直接来自 provider 的成功响应」与「内存/磁盘缓存命中、刷新失败后的降级数据」，避免缓存/降级列表覆盖真实列表并触发模型误纠错。

- `modelCache` 新增 `getModelsWithMetadata` / `refreshModelsWithMetadata`，返回 `ModelFetchResult = { models, authoritative }`；仅当数据来自成功的 provider 请求时 `authoritative` 为 `true`。原有 `getModels` / `refreshModels` 保留兼容包装。
- `costrict` fetcher 不再在请求失败时静默回退到磁盘缓存，改为向上抛出错误，由 `refreshModels` 的统一降级路径处理（返回缓存 + `authoritative: false`）。
- `flushModels` 的回调新增 `metadata` 参数；webview 在 `costrictModels` 消息中携带 `modelListAuthoritative`。
- 前端 `ProviderRenderer` 仅在「权威列表」时更新纠错基线、允许自动纠错，并在已有权威列表时不再被缓存数据覆盖；`getCorrectedCostrictModelId` 对非权威列表直接返回 `null`。

### Test Procedure

- 单元测试（本地 `vitest run` 全部通过）：
  - `src/api/providers/fetchers/__tests__/modelCache.spec.ts`：新增「authority metadata」用例（权威响应 / 缓存命中 / 刷新降级）。
  - `src/core/webview/__tests__/webviewMessageHandler.spec.ts`：新增「直接 provider 结果标记为 authoritative」用例，并补齐既有用例的 `modelListAuthoritative` 断言。
  - `src/core/webview/__tests__/ClineProvider.spec.ts`：Router Models 用例补齐 `getModelsWithMetadata` mock 与 `modelListAuthoritative` 断言。
  - `webview-ui/src/components/settings/utils/correctModelSelection.spec.ts`：新增「非权威列表返回 null」用例。
- 复现验证：provider 接口异常时，模型下拉应保留上次权威列表（不被空/缓存列表覆盖），且不会把已选模型误纠正为其他模型。
- `pnpm lint` 通过（commit pre-commit hook 已执行）。

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [ ] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

无 UI 视觉变更（仅模型选择行为修正）。

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

- 未关联 issue 编号；如团队要求每个 PR 关联 issue，请补充。
- 未运行完整 `pnpm build` 与 `npm run changeset`；如需 changeset（本变更影响模型选择这一用户可感知行为），可按需补充。

### Get in Touch

<!-- Discord 用户名待补充 -->
